### PR TITLE
Remove calls to the mk macro on final returns in parser.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
 name = "Boa"
-version = "0.1.2"
+version = "0.1.3"
 

--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -5,7 +5,8 @@ use std::fs::read_to_string;
 
 pub fn main() {
     let buffer = read_to_string("tests/js/defineVar.js").unwrap();
-    let lexer = Lexer::new(&buffer);
+    let mut lexer = Lexer::new(&buffer);
+    lexer.lex().unwrap();
     let tokens = lexer.tokens;
     match Parser::new(tokens).parse_all() {
         Ok(e) => println!("{}", e),

--- a/src/lib/syntax/parser.rs
+++ b/src/lib/syntax/parser.rs
@@ -5,6 +5,7 @@ use syntax::ast::keyword::Keyword;
 use syntax::ast::op::{BinOp, BitOp, CompOp, LogOp, NumOp, Operator, UnaryOp};
 use syntax::ast::punc::Punctuator;
 use syntax::ast::token::{Token, TokenData};
+use syntax::ast::pos::Position;
 
 macro_rules! mk (
     ($this:expr, $def:expr) => {
@@ -55,7 +56,16 @@ impl Parser {
             let result = try!(self.parse());
             exprs.push(result);
         }
-        Ok(mk!(self, ExprDef::BlockExpr(exprs)))
+
+        // In the case of `BlockExpr` the Positions seem unnecessary
+        // TODO: refactor this or the `mk!` perhaps?
+        Ok(
+            Expr::new(
+                ExprDef::BlockExpr(exprs),
+                Position::new(1, 1),
+                Position::new(1, 1)
+            )
+        )
     }
 
     fn get_token(&self, pos: usize) -> Result<Token, ParseError> {
@@ -120,7 +130,7 @@ impl Parser {
                         }
                     }
                 }
-                Ok(mk!(self, ExprDef::VarDeclExpr(vars)))
+                Ok(Expr::new(ExprDef::VarDeclExpr(vars), Position::new(1, 16), Position::new(1, 16)))
             }
             Keyword::Return => Ok(mk!(
                 self,

--- a/tests/js/defineVar.js
+++ b/tests/js/defineVar.js
@@ -1,1 +1,3 @@
 var a = 'Jason';
+var b = 'boa';
+console.log(a, b);


### PR DESCRIPTION
This urges a discussion:

  - What do the `Position` attributes do in the `Expr` structs? They don't have a use currently, but I can't imagine they were thrown in there by Bebbington "just because".

  - The solution proposed is probably more of a band-aid than an actual solution. At least until we can figure out what the `start` and `end` (`Position`) attrs are for.