### PR TITLE
Removed Position attributes from the Expr structs

### DIFF
--- a/src/lib/syntax/ast/expr.rs
+++ b/src/lib/syntax/ast/expr.rs
@@ -2,25 +2,18 @@ use std::collections::btree_map::BTreeMap;
 use std::fmt::{Display, Formatter, Result};
 use syntax::ast::constant::Const;
 use syntax::ast::op::{BinOp, Operator, UnaryOp};
-use syntax::ast::pos::Position;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Expr {
     /// The expression definition
     pub def: ExprDef,
-    /// The starting position
-    pub start: Position,
-    /// The ending position
-    pub end: Position,
 }
 
 impl Expr {
     /// Create a new expression with a starting and ending position
-    pub fn new(def: ExprDef, start: Position, end: Position) -> Expr {
+    pub fn new(def: ExprDef) -> Expr {
         Expr {
             def: def,
-            start: start,
-            end: end,
         }
     }
 }

--- a/src/lib/syntax/parser.rs
+++ b/src/lib/syntax/parser.rs
@@ -5,16 +5,15 @@ use syntax::ast::keyword::Keyword;
 use syntax::ast::op::{BinOp, BitOp, CompOp, LogOp, NumOp, Operator, UnaryOp};
 use syntax::ast::punc::Punctuator;
 use syntax::ast::token::{Token, TokenData};
-use syntax::ast::pos::Position;
 
 macro_rules! mk (
     ($this:expr, $def:expr) => {
         {
-            Expr::new($def, try!($this.get_token($this.pos)).pos, try!($this.get_token($this.pos)).pos)
+            Expr::new($def)
         }
     };
     ($this:expr, $def:expr, $first:expr) => {
-        Expr::new($def, $first.pos, try!($this.get_token($this.pos)).pos)
+        Expr::new($def)
     };
 );
 
@@ -61,9 +60,7 @@ impl Parser {
         // TODO: refactor this or the `mk!` perhaps?
         Ok(
             Expr::new(
-                ExprDef::BlockExpr(exprs),
-                Position::new(1, 1),
-                Position::new(1, 1)
+                ExprDef::BlockExpr(exprs)
             )
         )
     }
@@ -130,7 +127,7 @@ impl Parser {
                         }
                     }
                 }
-                Ok(Expr::new(ExprDef::VarDeclExpr(vars), Position::new(1, 16), Position::new(1, 16)))
+                Ok(Expr::new(ExprDef::VarDeclExpr(vars)))
             }
             Keyword::Return => Ok(mk!(
                 self,

--- a/tests/js/defineVar.js
+++ b/tests/js/defineVar.js
@@ -1,3 +1,6 @@
-var a = 'Jason';
-var b = 'boa';
-console.log(a, b);
+var b = 'Jason';
+if(1===1){
+  b = 'another name';
+}
+
+console.log(b);


### PR DESCRIPTION
- Removed the `Position` (`start` and `end`) attributes from the `Expr` struct as it didn't seem like they were currently necessary.

- Nested blocks (i.e. `if` statements) now get parsed correctly