### PR TITLE
make wasm-bindgen an optional feature, but installed by default, fixes #21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,18 @@ license = "Unlicense OR MIT"
 exclude = [".vscode/*", "Dockerfile", "Makefile", ".editorConfig"]
 edition = "2018"
 
+[features]
+default = ["wasm-bindgen"]
+
 [dependencies]
 gc = "0.3.2"
 gc_derive = "0.3.2"
 serde_json = "1.0"
 rand = "0.5.5"
 chrono = "0.4"
-wasm-bindgen = "0.2.43"
+
+# Optional Dependencies
+wasm-bindgen = { version = "0.2.43", optional = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
@shekohex at some point im sure thre will be a `boa-core` but this is the best i can do for now.

