### PR TITLE
Add ability to specify a file to read from to the Boa binary (#35)

### DIFF
--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -1,8 +1,37 @@
 extern crate boa;
 use boa::exec;
 use std::fs::read_to_string;
+use std::env;
+use std::process::exit;
 
-pub fn main() {
-    let buffer = read_to_string("tests/js/test.js").unwrap();
+fn print_usage() {
+    println!("Usage:
+boa [file.js]
+    Interpret and execute file.js
+    (if no file given, defaults to tests/js/test.js");
+}
+
+pub fn main() -> Result<(), std::io::Error> {
+    let args: Vec<String> = env::args().collect();
+    let read_file;
+
+    match args.len() {
+        // No arguments passed, default to "test.js"
+        1 => {
+            read_file = "tests/js/test.js";
+        },
+        // One argument passed, assumed this is the test file
+        2 => {
+            read_file = &args[1];
+        }
+        // Some other number of arguments passed: not supported
+        _ => {
+            print_usage();
+            exit(1);
+        }
+    }
+
+    let buffer = read_to_string(read_file)?;
     dbg!(exec(buffer));
+    Ok(())
 }


### PR DESCRIPTION
Adds argument parsing in the main function of bin.rs which enables specifying a CLI argument as the file to read from: if not argument is specified, it still defaults to tests/js/test.js. #35 

Also adds and prints usage information on incorrect CLI options (and rudimentary error reporting, for the case the file specified doesn't exists, by implict `Result<E, T>` conversion):

```
Usage:
boa [file.js]
    Interpret and execute file.js
    (if no file given, defaults to tests/js/test.js")
```

Where "boa" is the debug binary created by `cargo`: `target/debug/bin`.