### PR TITLE
Parser tests

### DIFF
--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -1,14 +1,16 @@
 extern crate boa;
 use boa::exec;
-use std::fs::read_to_string;
 use std::env;
+use std::fs::read_to_string;
 use std::process::exit;
 
 fn print_usage() {
-    println!("Usage:
+    println!(
+        "Usage:
 boa [file.js]
     Interpret and execute file.js
-    (if no file given, defaults to tests/js/test.js");
+    (if no file given, defaults to tests/js/test.js"
+    );
 }
 
 pub fn main() -> Result<(), std::io::Error> {
@@ -19,7 +21,7 @@ pub fn main() -> Result<(), std::io::Error> {
         // No arguments passed, default to "test.js"
         1 => {
             read_file = "tests/js/test.js";
-        },
+        }
         // One argument passed, assumed this is the test file
         2 => {
             read_file = &args[1];

--- a/src/lib/environment/environment_record_trait.rs
+++ b/src/lib/environment/environment_record_trait.rs
@@ -3,7 +3,7 @@
 //! https://tc39.github.io/ecma262/#sec-environment-records
 //! https://tc39.github.io/ecma262/#sec-lexical-environments
 //!
-//! Some environments are stored as JSObjects. This is for GC, i.e we want to keep an environment if a variable is closed-over (a closure is returned).   
+//! Some environments are stored as JSObjects. This is for GC, i.e we want to keep an environment if a variable is closed-over (a closure is returned).
 //! All of the logic to handle scope/environment records are stored in here.
 //!
 //! There are 5 Environment record kinds. They all have methods in common, these are implemented as a the `EnvironmentRecordTrait`

--- a/src/lib/syntax/ast/token.rs
+++ b/src/lib/syntax/ast/token.rs
@@ -1,7 +1,7 @@
-use std::fmt::{Debug, Display, Formatter, Result};
 use crate::syntax::ast::keyword::Keyword;
 use crate::syntax::ast::pos::Position;
 use crate::syntax::ast::punc::Punctuator;
+use std::fmt::{Debug, Display, Formatter, Result};
 
 #[derive(Clone, PartialEq)]
 /// Represents a token

--- a/src/lib/syntax/parser.rs
+++ b/src/lib/syntax/parser.rs
@@ -770,6 +770,10 @@ mod tests {
         let mut lexer = Lexer::new(js);
         lexer.lex().unwrap();
 
+        dbg!(Parser::new(lexer.tokens).parse_all().unwrap());
+        let mut lexer = Lexer::new(js);
+        lexer.lex().unwrap();
+
         assert_eq!(
             Parser::new(lexer.tokens).parse_all().unwrap(),
             Expr::new(ExprDef::BlockExpr(expr.into()))
@@ -788,10 +792,18 @@ mod tests {
         use crate::syntax::ast::constant::Const;
 
         // Check empty string
-        check_parser("\"\"", &[Expr::new(ExprDef::ConstExpr(Const::String(String::new())))]);
+        check_parser(
+            "\"\"",
+            &[Expr::new(ExprDef::ConstExpr(Const::String(String::new())))],
+        );
 
         // Check non-empty string
-        check_parser("\"hello\"", &[Expr::new(ExprDef::ConstExpr(Const::String(String::from("hello"))))]);
+        check_parser(
+            "\"hello\"",
+            &[Expr::new(ExprDef::ConstExpr(Const::String(String::from(
+                "hello",
+            ))))],
+        );
     }
 
     #[test]
@@ -807,11 +819,14 @@ mod tests {
         // check_parser("[,]", &[Expr::new(ExprDef::ArrayDeclExpr(vec![]))]);
 
         // Check numeric array
-        check_parser("[1, 2, 3]", &[Expr::new(ExprDef::ArrayDeclExpr(vec![
-            Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
-            Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
-            Expr::new(ExprDef::ConstExpr(Const::Num(3.0))),
-        ]))]);
+        check_parser(
+            "[1, 2, 3]",
+            &[Expr::new(ExprDef::ArrayDeclExpr(vec![
+                Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(3.0))),
+            ]))],
+        );
 
         // Check numeric array with trailing comma
         // FIXME: This does not work, it should ignore the trailing comma:
@@ -823,18 +838,24 @@ mod tests {
         // ]))]);
 
         // Check combined array
-        check_parser("[1, \"a\", 2]", &[Expr::new(ExprDef::ArrayDeclExpr(vec![
-            Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
-            Expr::new(ExprDef::ConstExpr(Const::String(String::from("a")))),
-            Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
-        ]))]);
+        check_parser(
+            "[1, \"a\", 2]",
+            &[Expr::new(ExprDef::ArrayDeclExpr(vec![
+                Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+                Expr::new(ExprDef::ConstExpr(Const::String(String::from("a")))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+            ]))],
+        );
 
         // Check combined array with empty string
-        check_parser("[1, \"\", 2]", &[Expr::new(ExprDef::ArrayDeclExpr(vec![
-            Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
-            Expr::new(ExprDef::ConstExpr(Const::String(String::new()))),
-            Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
-        ]))]);
+        check_parser(
+            "[1, \"\", 2]",
+            &[Expr::new(ExprDef::ArrayDeclExpr(vec![
+                Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+                Expr::new(ExprDef::ConstExpr(Const::String(String::new()))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+            ]))],
+        );
     }
 
     #[test]
@@ -842,78 +863,108 @@ mod tests {
         use crate::syntax::ast::constant::Const;
 
         // Check `var` declaration
-        check_parser("var a = 5;", &[Expr::new(ExprDef::VarDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "var a = 5;",
+            &[Expr::new(ExprDef::VarDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check `var` declaration with no spaces
-        check_parser("var a=5;", &[Expr::new(ExprDef::VarDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "var a=5;",
+            &[Expr::new(ExprDef::VarDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check empty `var` declaration
-        check_parser("var a;", &[Expr::new(ExprDef::VarDeclExpr(vec![(
-            String::from("a"),
-            None
-        ),]))]);
+        check_parser(
+            "var a;",
+            &[Expr::new(ExprDef::VarDeclExpr(vec![(
+                String::from("a"),
+                None,
+            )]))],
+        );
 
         // Check multiple `var` declaration
-        check_parser("var a = 5, b, c = 6;", &[Expr::new(ExprDef::VarDeclExpr(vec![
-            (
-                String::from("a"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-            ),
-            (String::from("b"), None),
-            (
-                String::from("c"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0))))
-            ),
-        ]))]);
+        check_parser(
+            "var a = 5, b, c = 6;",
+            &[Expr::new(ExprDef::VarDeclExpr(vec![
+                (
+                    String::from("a"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+                ),
+                (String::from("b"), None),
+                (
+                    String::from("c"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0)))),
+                ),
+            ]))],
+        );
 
         // Check `let` declaration
-        check_parser("let a = 5;", &[Expr::new(ExprDef::LetDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "let a = 5;",
+            &[Expr::new(ExprDef::LetDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check `let` declaration with no spaces
-        check_parser("let a=5;", &[Expr::new(ExprDef::LetDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "let a=5;",
+            &[Expr::new(ExprDef::LetDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check empty `let` declaration
-        check_parser("let a;", &[Expr::new(ExprDef::LetDeclExpr(vec![(
-            String::from("a"),
-            None
-        ),]))]);
+        check_parser(
+            "let a;",
+            &[Expr::new(ExprDef::LetDeclExpr(vec![(
+                String::from("a"),
+                None,
+            )]))],
+        );
 
         // Check multiple `let` declaration
-        check_parser("let a = 5, b, c = 6;", &[Expr::new(ExprDef::LetDeclExpr(vec![
-            (
-                String::from("a"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-            ),
-            (String::from("b"), None),
-            (
-                String::from("c"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0))))
-            ),
-        ]))]);
+        check_parser(
+            "let a = 5, b, c = 6;",
+            &[Expr::new(ExprDef::LetDeclExpr(vec![
+                (
+                    String::from("a"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+                ),
+                (String::from("b"), None),
+                (
+                    String::from("c"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0)))),
+                ),
+            ]))],
+        );
 
         // Check `const` declaration
-        check_parser("const a = 5;", &[Expr::new(ExprDef::ConstDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "const a = 5;",
+            &[Expr::new(ExprDef::ConstDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check `const` declaration with no spaces
-        check_parser("const a=5;", &[Expr::new(ExprDef::ConstDeclExpr(vec![(
-            String::from("a"),
-            Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-        ),]))]);
+        check_parser(
+            "const a=5;",
+            &[Expr::new(ExprDef::ConstDeclExpr(vec![(
+                String::from("a"),
+                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+            )]))],
+        );
 
         // Check empty `const` declaration
         // FIXME: This does not work, it should fail to parse an unitialized const declaration:
@@ -921,16 +972,139 @@ mod tests {
         // check_invalid("const a;");
 
         // Check multiple `const` declaration
-        check_parser("const a = 5, b, c = 6;", &[Expr::new(ExprDef::ConstDeclExpr(vec![
-            (
-                String::from("a"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0))))
-            ),
-            (String::from("b"), None),
-            (
-                String::from("c"),
-                Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0))))
-            ),
-        ]))]);
+        check_parser(
+            "const a = 5, b, c = 6;",
+            &[Expr::new(ExprDef::ConstDeclExpr(vec![
+                (
+                    String::from("a"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(5.0)))),
+                ),
+                (String::from("b"), None),
+                (
+                    String::from("c"),
+                    Some(Expr::new(ExprDef::ConstExpr(Const::Num(6.0)))),
+                ),
+            ]))],
+        );
+    }
+
+    #[test]
+    fn check_operations() {
+        use crate::syntax::ast::constant::Const;
+
+        fn create_bin_op(op: NumOp, exp1: Expr, exp2: Expr) -> Expr {
+            use crate::syntax::ast::op::BinOp;
+
+            Expr::new(ExprDef::BinOpExpr(
+                BinOp::Num(op),
+                Box::new(exp1),
+                Box::new(exp2),
+            ))
+        }
+
+        // Check numeric operations
+        check_parser(
+            "a + b",
+            &[create_bin_op(
+                NumOp::Add,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::LocalExpr(String::from("b"))),
+            )],
+        );
+        check_parser(
+            "a+1",
+            &[create_bin_op(
+                NumOp::Add,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+            )],
+        );
+        check_parser(
+            "a - b",
+            &[create_bin_op(
+                NumOp::Sub,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::LocalExpr(String::from("b"))),
+            )],
+        );
+        check_parser(
+            "a-1",
+            &[create_bin_op(
+                NumOp::Sub,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+            )],
+        );
+        check_parser(
+            "a / b",
+            &[create_bin_op(
+                NumOp::Div,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::LocalExpr(String::from("b"))),
+            )],
+        );
+        check_parser(
+            "a/2",
+            &[create_bin_op(
+                NumOp::Div,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+            )],
+        );
+        check_parser(
+            "a * b",
+            &[create_bin_op(
+                NumOp::Mul,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::LocalExpr(String::from("b"))),
+            )],
+        );
+        check_parser(
+            "a*2",
+            &[create_bin_op(
+                NumOp::Mul,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+            )],
+        );
+        check_parser(
+            "a % b",
+            &[create_bin_op(
+                NumOp::Mod,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::LocalExpr(String::from("b"))),
+            )],
+        );
+        check_parser(
+            "a%2",
+            &[create_bin_op(
+                NumOp::Mod,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                Expr::new(ExprDef::ConstExpr(Const::Num(2.0))),
+            )],
+        );
+
+        // Check complex numeric operations
+        check_parser(
+            "a + d*(b-3)+1",
+            &[create_bin_op(
+                NumOp::Add,
+                Expr::new(ExprDef::LocalExpr(String::from("a"))),
+                create_bin_op(
+                    NumOp::Add,
+                    // FIXME: shouldn't the last addition be on the right?
+                    Expr::new(ExprDef::ConstExpr(Const::Num(1.0))),
+                    create_bin_op(
+                        NumOp::Mul,
+                        Expr::new(ExprDef::LocalExpr(String::from("d"))),
+                        create_bin_op(
+                            NumOp::Sub,
+                            Expr::new(ExprDef::LocalExpr(String::from("b"))),
+                            Expr::new(ExprDef::ConstExpr(Const::Num(3.0))),
+                        ),
+                    ),
+                ),
+            )],
+        );
     }
 }

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -1,2 +1,2 @@
-let a = "hello world";
+let a = [];
 a;

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -1,2 +1,7 @@
-let a = [];
-a;
+let a = 5;
+let b = 6;
+let c = 8;
+let d = 5;
+
+let res = a + d * (b - 3) + 1;
+res;


### PR DESCRIPTION
Hi!

This is my first contribution to the project, great work! I'm working on doing test for the parser (#40), and I've just created the first changes. Note that I ran `cargo fmt`, so there are minor format changes in other places.

I wanted to create the PR asap, so that you could review it and let me know if I'm following the proper procedure. Real changes are in the `src/lib/syntax/parser.rs` file, where I added a `tests` module. For now, it just contains tests for strings, arrays and declarations.

I found some errors in the parser, though:
 - Trailing commas in array assignments make the parser fail ([spec link][array_assignment]).
 - `const` declarations work with empty expressions when they shouldnt ([spec_link][empty_const]).

For this last error, I would suggest to change the definition of `syntax::ast::expr::ExprDef::ConstDeclExpr` to directly not allow an `Option` in the expression.

Let me know if you like the design, and I'll implement the tests for the rest of the expressions!

[array_assignment]: https://tc39.es/ecma262/#prod-ArrayAssignmentPattern
[empty_const]: https://tc39.es/ecma262/#sec-let-and-const-declarations-static-semantics-early-errors