### PR TITLE
Implement bare Array object with prototype field

### DIFF
--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -1,14 +1,16 @@
 extern crate boa;
 use boa::exec;
-use std::fs::read_to_string;
 use std::env;
+use std::fs::read_to_string;
 use std::process::exit;
 
 fn print_usage() {
-    println!("Usage:
+    println!(
+        "Usage:
 boa [file.js]
     Interpret and execute file.js
-    (if no file given, defaults to tests/js/test.js");
+    (if no file given, defaults to tests/js/test.js"
+    );
 }
 
 pub fn main() -> Result<(), std::io::Error> {
@@ -19,7 +21,7 @@ pub fn main() -> Result<(), std::io::Error> {
         // No arguments passed, default to "test.js"
         1 => {
             read_file = "tests/js/test.js";
-        },
+        }
         // One argument passed, assumed this is the test file
         2 => {
             read_file = &args[1];

--- a/src/lib/environment/environment_record_trait.rs
+++ b/src/lib/environment/environment_record_trait.rs
@@ -3,7 +3,7 @@
 //! https://tc39.github.io/ecma262/#sec-environment-records
 //! https://tc39.github.io/ecma262/#sec-lexical-environments
 //!
-//! Some environments are stored as JSObjects. This is for GC, i.e we want to keep an environment if a variable is closed-over (a closure is returned).   
+//! Some environments are stored as JSObjects. This is for GC, i.e we want to keep an environment if a variable is closed-over (a closure is returned).
 //! All of the logic to handle scope/environment records are stored in here.
 //!
 //! There are 5 Environment record kinds. They all have methods in common, these are implemented as a the `EnvironmentRecordTrait`

--- a/src/lib/js/array.rs
+++ b/src/lib/js/array.rs
@@ -1,7 +1,6 @@
 use crate::js::function::NativeFunctionData;
 use crate::js::object::{Property, PROTOTYPE, ObjectData};
 use crate::js::value::{from_value, to_value, ResultValue, Value, ValueData};
-use std::collections::HashMap;
 use gc::Gc;
 
 /// Create a new array

--- a/src/lib/js/array.rs
+++ b/src/lib/js/array.rs
@@ -1,5 +1,5 @@
 use crate::js::function::NativeFunctionData;
-use crate::js::object::{Property, PROTOTYPE, ObjectData};
+use crate::js::object::{Property, PROTOTYPE};
 use crate::js::value::{from_value, to_value, ResultValue, Value, ValueData};
 use gc::Gc;
 
@@ -44,7 +44,7 @@ pub fn _create(global: &Value) -> Value {
         writable: false,
         value: Gc::new(ValueData::Undefined),
         get: to_value(get_array_length as NativeFunctionData),
-        set: Gc::new(ValueData::Undefined)
+        set: Gc::new(ValueData::Undefined),
     };
     proto.set_prop_slice("length", length);
     array.set_field_slice(PROTOTYPE, proto);

--- a/src/lib/js/array.rs
+++ b/src/lib/js/array.rs
@@ -8,7 +8,6 @@ pub fn make_array(this: Value, _: Value, args: Vec<Value>) -> ResultValue {
     let this_ptr = this.clone();
     // Make a new Object which will internally represent the Array (mapping
     // between indices and values): this creates an Object with no prototype
-    let array_obj = ValueData::new_obj(None);
     match args.len() {
         0 => {
             this_ptr.set_field_slice("length", to_value(0i32));
@@ -21,11 +20,10 @@ pub fn make_array(this: Value, _: Value, args: Vec<Value>) -> ResultValue {
             this_ptr.set_field_slice("length", to_value(n));
             for k in 0..n {
                 let index_str = k.to_string();
-                array_obj.set_field(index_str, args[k].clone());
+                this_ptr.set_field(index_str, args[k].clone());
             }
         }
     }
-    this_ptr.set_field_slice("ArrayObject", array_obj);
     Ok(this_ptr)
 }
 
@@ -33,10 +31,7 @@ pub fn make_array(this: Value, _: Value, args: Vec<Value>) -> ResultValue {
 pub fn get_array_length(this: Value, _: Value, _: Vec<Value>) -> ResultValue {
     // Access the inner hash map which represents the actual Array contents
     // (mapping between indices and values)
-    let this_array: ObjectData = 
-        from_value(this.get_field(String::from("ArrayObject")))
-        .unwrap();
-    Ok(to_value(this_array.len() as i32))
+    Ok(this.get_field_slice("length"))
 }
 
 /// Create a new `Array` object

--- a/src/lib/js/array.rs
+++ b/src/lib/js/array.rs
@@ -1,19 +1,61 @@
 use crate::js::function::NativeFunctionData;
-use crate::js::value::{to_value, ResultValue, Value, ValueData};
+use crate::js::object::{Property, PROTOTYPE, ObjectData};
+use crate::js::value::{from_value, to_value, ResultValue, Value, ValueData};
+use std::collections::HashMap;
 use gc::Gc;
 
 /// Create a new array
-pub fn make_array(this: Value, _: Value, _: Vec<Value>) -> ResultValue {
+pub fn make_array(this: Value, _: Value, args: Vec<Value>) -> ResultValue {
     let this_ptr = this.clone();
-    this_ptr.set_field_slice("length", to_value(0i32));
-    Ok(Gc::new(ValueData::Undefined))
+    match args.len() {
+        0 => {
+            this_ptr.set_field_slice("length", to_value(0i32));
+            let array_obj: ObjectData = HashMap::new();
+            this_ptr.set_private_field_slice("ArrayValue", to_value(array_obj));
+        }
+        1 => {
+            let length_chosen: i32 = from_value(args[0]).unwrap();
+            this_ptr.set_field_slice("length", to_value(length_chosen));
+            let array_obj: ObjectData = HashMap::with_capacity(length_chosen as usize);
+            this_ptr.set_private_field_slice("ArrayValue", to_value(array_obj));
+        }
+        n => {
+            this_ptr.set_field_slice("length", to_value(n));
+            let array_obj: ObjectData = HashMap::new();
+            for k in 0..n {
+                let index_str = k.to_string();
+                array_obj.insert(index_str, Property::new(from_value(args[k]).unwrap()));
+            }
+        }
+    }
+    Ok(to_value(this_ptr))
 }
+
+/// Get an array's length
+pub fn get_array_length(this: Value, _: Value, _: Vec<Value>) -> ResultValue {
+    let this_array: ObjectData = 
+        from_value(this.get_private_field(String::from("PrimitiveValue")))
+        .unwrap();
+    Ok(to_value(this_array.len() as i32))
+}
+
 /// Create a new `Array` object
-pub fn _create() -> Value {
+pub fn _create(global: &Value) -> Value {
     let array = to_value(make_array as NativeFunctionData);
+    let proto = ValueData::new_obj(Some(global));
+    let length = Property {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: Gc::new(ValueData::Undefined),
+        get: to_value(get_array_length as NativeFunctionData),
+        set: Gc::new(ValueData::Undefined)
+    };
+    proto.set_prop_slice("length", length);
+    array.set_field_slice(PROTOTYPE, proto);
     array
 }
 /// Initialise the global object with the `Array` object
 pub fn init(global: &Value) {
-    global.set_field_slice("Array", _create());
+    global.set_field_slice("Array", _create(global));
 }

--- a/src/lib/syntax/ast/token.rs
+++ b/src/lib/syntax/ast/token.rs
@@ -1,7 +1,7 @@
-use std::fmt::{Debug, Display, Formatter, Result};
 use crate::syntax::ast::keyword::Keyword;
 use crate::syntax::ast::pos::Position;
 use crate::syntax::ast::punc::Punctuator;
+use std::fmt::{Debug, Display, Formatter, Result};
 
 #[derive(Clone, PartialEq)]
 /// Represents a token


### PR DESCRIPTION
This PR implements the basis of the Array object (and its internal representation) similarly to String. This is part of the work towards completion of Array prototype methods #36. 

It uses an internal Object to store the mapping between indices and Values. This may need review (does this still work with Array indexing etc), and otherwise an alternative approach will need to be developed through this PR.