### PR TITLE
Parse array elisions and trailing commas

### DIFF
--- a/src/lib/syntax/parser.rs
+++ b/src/lib/syntax/parser.rs
@@ -811,9 +811,9 @@ mod tests {
         // Check array with empty slot
         check_parser(
             "[,]",
-            &[Expr::new(ExprDef::ArrayDeclExpr(vec![
-                Expr::new(ExprDef::ConstExpr(Const::Undefined))
-            ]))],
+            &[Expr::new(ExprDef::ArrayDeclExpr(vec![Expr::new(
+                ExprDef::ConstExpr(Const::Undefined),
+            )]))],
         );
 
         // Check numeric array


### PR DESCRIPTION
Hey Jason, just saw your JSConf EU talk, it was great!

I have added support for parsing arrays which include elisions as well as trailing commas. The elision is parsed into an "undefined", but I'm not sure if that's semantically the best thing to do. Perhaps a new expression should be used to indicate that an element has been elided or the metadata should be stored on the array node. Fixes #45.