### PR TITLE
Spelling edit to file names, functions, and vars: decler* -> declar*

### DIFF
--- a/src/lib/environment/declarative_environment_record.rs
+++ b/src/lib/environment/declarative_environment_record.rs
@@ -1,4 +1,4 @@
-//! # Declerative Records
+//! # Declarative Records
 //!
 //! Each declarative Environment Record is associated with an ECMAScript program scope containing variable,
 //! `constant`, `let`, `class`, `module`, `import`, and/or function declarations.
@@ -16,13 +16,13 @@ use gc::Gc;
 use gc_derive::{Finalize, Trace};
 use std::collections::hash_map::HashMap;
 
-/// Declerative Bindings have a few properties for book keeping purposes, such as mutability (const vs let).
+/// Declarative Bindings have a few properties for book keeping purposes, such as mutability (const vs let).
 /// Can it be deleted? and strict mode.
 ///
 /// So we need to create a struct to hold these values.
 /// From this point onwards, a binding is referring to one of these structures.
 #[derive(Trace, Finalize, Debug, Clone)]
-pub struct DeclerativeEnvironmentRecordBinding {
+pub struct DeclarativeEnvironmentRecordBinding {
     pub value: Option<Value>,
     pub can_delete: bool,
     pub mutable: bool,
@@ -32,12 +32,12 @@ pub struct DeclerativeEnvironmentRecordBinding {
 /// A declarative Environment Record binds the set of identifiers defined by the
 /// declarations contained within its scope.
 #[derive(Debug, Trace, Finalize, Clone)]
-pub struct DeclerativeEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclerativeEnvironmentRecordBinding>,
+pub struct DeclarativeEnvironmentRecord {
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
     pub outer_env: Option<Environment>,
 }
 
-impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
+impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
     fn has_binding(&self, name: &str) -> bool {
         self.env_rec.contains_key(name)
     }
@@ -50,7 +50,7 @@ impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
 
         self.env_rec.insert(
             name,
-            DeclerativeEnvironmentRecordBinding {
+            DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: deletion,
                 mutable: true,
@@ -67,7 +67,7 @@ impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
 
         self.env_rec.insert(
             name,
-            DeclerativeEnvironmentRecordBinding {
+            DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: true,
                 mutable: false,
@@ -102,7 +102,7 @@ impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
             return;
         }
 
-        let record: &mut DeclerativeEnvironmentRecordBinding = self.env_rec.get_mut(name).unwrap();
+        let record: &mut DeclarativeEnvironmentRecordBinding = self.env_rec.get_mut(name).unwrap();
         if record.strict {
             strict = true
         }
@@ -121,7 +121,7 @@ impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
 
     fn get_binding_value(&self, name: &str, _strict: bool) -> Value {
         if self.env_rec.get(name).is_some() && self.env_rec.get(name).unwrap().value.is_some() {
-            let record: &DeclerativeEnvironmentRecordBinding = self.env_rec.get(name).unwrap();
+            let record: &DeclarativeEnvironmentRecordBinding = self.env_rec.get(name).unwrap();
             record.value.as_ref().unwrap().clone()
         } else {
             // TODO: change this when error handling comes into play
@@ -163,7 +163,7 @@ impl EnvironmentRecordTrait for DeclerativeEnvironmentRecord {
     }
 
     fn get_environment_type(&self) -> EnvironmentType {
-        EnvironmentType::Declerative
+        EnvironmentType::Declarative
     }
 
     fn get_global_object(&self) -> Option<Value> {

--- a/src/lib/environment/function_environment_record.rs
+++ b/src/lib/environment/function_environment_record.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     environment::{
-        declerative_environment_record::DeclerativeEnvironmentRecordBinding,
+        declarative_environment_record::DeclarativeEnvironmentRecordBinding,
         environment_record_trait::EnvironmentRecordTrait,
         lexical_environment::{Environment, EnvironmentType},
     },
@@ -35,7 +35,7 @@ pub enum BindingStatus {
 /// <https://tc39.github.io/ecma262/#table-16>
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct FunctionEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclerativeEnvironmentRecordBinding>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
     /// This is the this value used for this invocation of the function.
     pub this_value: Value,
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.
@@ -107,7 +107,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
         self.env_rec.insert(
             name,
-            DeclerativeEnvironmentRecordBinding {
+            DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: deletion,
                 mutable: true,
@@ -124,7 +124,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
         self.env_rec.insert(
             name,
-            DeclerativeEnvironmentRecordBinding {
+            DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: true,
                 mutable: false,
@@ -159,7 +159,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
             return;
         }
 
-        let record: &mut DeclerativeEnvironmentRecordBinding = self.env_rec.get_mut(name).unwrap();
+        let record: &mut DeclarativeEnvironmentRecordBinding = self.env_rec.get_mut(name).unwrap();
         if record.strict {
             strict = true
         }
@@ -179,7 +179,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn get_binding_value(&self, name: &str, _strict: bool) -> Value {
         if self.env_rec.get(name).is_some() && self.env_rec.get(name).unwrap().value.is_some() {
-            let record: &DeclerativeEnvironmentRecordBinding = self.env_rec.get(name).unwrap();
+            let record: &DeclarativeEnvironmentRecordBinding = self.env_rec.get(name).unwrap();
             record.value.as_ref().unwrap().clone()
         } else {
             // TODO: change this when error handling comes into play

--- a/src/lib/environment/global_environment_record.rs
+++ b/src/lib/environment/global_environment_record.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     environment::{
-        declerative_environment_record::DeclerativeEnvironmentRecord,
+        declarative_environment_record::DeclarativeEnvironmentRecord,
         environment_record_trait::EnvironmentRecordTrait,
         lexical_environment::{Environment, EnvironmentType},
         object_environment_record::ObjectEnvironmentRecord,
@@ -24,7 +24,7 @@ use std::collections::HashSet;
 pub struct GlobalEnvironmentRecord {
     pub object_record: Box<ObjectEnvironmentRecord>,
     pub global_this_binding: Value,
-    pub declerative_record: Box<DeclerativeEnvironmentRecord>,
+    pub declarative_record: Box<DeclarativeEnvironmentRecord>,
     pub var_names: HashSet<String>,
 }
 
@@ -33,12 +33,12 @@ impl GlobalEnvironmentRecord {
         self.global_this_binding.clone()
     }
 
-    pub fn has_var_decleration(&self, name: &str) -> bool {
+    pub fn has_var_declaration(&self, name: &str) -> bool {
         self.var_names.contains(name)
     }
 
-    pub fn has_lexical_decleration(&self, name: &str) -> bool {
-        self.declerative_record.has_binding(name)
+    pub fn has_lexical_declaration(&self, name: &str) -> bool {
+        self.declarative_record.has_binding(name)
     }
 
     pub fn has_restricted_global_property(&self, name: &str) -> bool {
@@ -92,60 +92,60 @@ impl GlobalEnvironmentRecord {
 
 impl EnvironmentRecordTrait for GlobalEnvironmentRecord {
     fn has_binding(&self, name: &str) -> bool {
-        if self.declerative_record.has_binding(name) {
+        if self.declarative_record.has_binding(name) {
             return true;
         }
         self.object_record.has_binding(name)
     }
 
     fn create_mutable_binding(&mut self, name: String, deletion: bool) {
-        if self.declerative_record.has_binding(&name) {
+        if self.declarative_record.has_binding(&name) {
             // TODO: change to exception
             panic!("Binding already exists!");
         }
 
-        self.declerative_record
+        self.declarative_record
             .create_mutable_binding(name.clone(), deletion)
     }
 
     fn create_immutable_binding(&mut self, name: String, strict: bool) -> bool {
-        if self.declerative_record.has_binding(&name) {
+        if self.declarative_record.has_binding(&name) {
             // TODO: change to exception
             panic!("Binding already exists!");
         }
 
-        self.declerative_record
+        self.declarative_record
             .create_immutable_binding(name.clone(), strict)
     }
 
     fn initialize_binding(&mut self, name: &str, value: Value) {
-        if self.declerative_record.has_binding(&name) {
+        if self.declarative_record.has_binding(&name) {
             // TODO: assert binding is in the object environment record
-            return self.declerative_record.initialize_binding(name, value);
+            return self.declarative_record.initialize_binding(name, value);
         }
 
         panic!("Should not initialized binding without creating first.");
     }
 
     fn set_mutable_binding(&mut self, name: &str, value: Value, strict: bool) {
-        if self.declerative_record.has_binding(&name) {
+        if self.declarative_record.has_binding(&name) {
             return self
-                .declerative_record
+                .declarative_record
                 .set_mutable_binding(name, value, strict);
         }
         self.object_record.set_mutable_binding(name, value, strict)
     }
 
     fn get_binding_value(&self, name: &str, strict: bool) -> Value {
-        if self.declerative_record.has_binding(&name) {
-            return self.declerative_record.get_binding_value(name, strict);
+        if self.declarative_record.has_binding(&name) {
+            return self.declarative_record.get_binding_value(name, strict);
         }
         self.object_record.get_binding_value(name, strict)
     }
 
     fn delete_binding(&mut self, name: &str) -> bool {
-        if self.declerative_record.has_binding(&name) {
-            return self.declerative_record.delete_binding(name);
+        if self.declarative_record.has_binding(&name) {
+            return self.declarative_record.delete_binding(name);
         }
 
         let global: &Value = &self.object_record.bindings;

--- a/src/lib/environment/lexical_environment.rs
+++ b/src/lib/environment/lexical_environment.rs
@@ -6,7 +6,7 @@
 //! This is the entrypoint to lexical environments.
 //!
 
-use crate::environment::declerative_environment_record::DeclerativeEnvironmentRecord;
+use crate::environment::declarative_environment_record::DeclarativeEnvironmentRecord;
 use crate::environment::environment_record_trait::EnvironmentRecordTrait;
 use crate::environment::function_environment_record::{BindingStatus, FunctionEnvironmentRecord};
 use crate::environment::global_environment_record::GlobalEnvironmentRecord;
@@ -26,7 +26,7 @@ pub type Environment = Gc<GcCell<Box<dyn EnvironmentRecordTrait>>>;
 /// This helps with comparisons
 #[derive(Debug, Clone, Copy)]
 pub enum EnvironmentType {
-    Declerative,
+    Declarative,
     Function,
     Global,
     Object,
@@ -155,8 +155,8 @@ impl LexicalEnvironment {
     }
 }
 
-pub fn new_declerative_environment(env: Option<Environment>) -> Environment {
-    let boxed_env = Box::new(DeclerativeEnvironmentRecord {
+pub fn new_declarative_environment(env: Option<Environment>) -> Environment {
+    let boxed_env = Box::new(DeclarativeEnvironmentRecord {
         env_rec: HashMap::new(),
         outer_env: env,
     });
@@ -207,7 +207,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
         with_environment: false,
     });
 
-    let dcl_rec = Box::new(DeclerativeEnvironmentRecord {
+    let dcl_rec = Box::new(DeclarativeEnvironmentRecord {
         env_rec: HashMap::new(),
         outer_env: None,
     });
@@ -215,7 +215,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
     Gc::new(GcCell::new(Box::new(GlobalEnvironmentRecord {
         object_record: obj_rec,
         global_this_binding: this_value,
-        declerative_record: dcl_rec,
+        declarative_record: dcl_rec,
         var_names: HashSet::new(),
     })))
 }

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -1,4 +1,4 @@
-pub mod declerative_environment_record;
+pub mod declarative_environment_record;
 pub mod environment_record_trait;
 pub mod function_environment_record;
 pub mod global_environment_record;


### PR DESCRIPTION
- No functionality gains or bug fixes, just spelling edits