### PR TITLE
replacing ExecutorBuilder with Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Features:
   Enables Boa to run within the Test 262 framework.  
   This will help us see what is implemented or not within the spec
 
+# Next
+
+Feature enhancements:
+
+- [FEATURE #119](https://github.com/jasonwilliams/boa/issues/119):
+  Introduce realm struct to hold realm context and global object
+
 # 0.4.0 (2019-09-25)
 
 v0.4.0 brings quite a big release. The biggest feature to land is the support of regular expressions.  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ harness = false
 name = "fib"
 harness = false
 
+[[bench]]
+name = "exec"
+harness = false
+
 [[bin]]
 name = "boa"
 path = "src/bin/bin.rs"

--- a/benches/exec.rs
+++ b/benches/exec.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate criterion;
+
+use boa::realm::Realm;
+use criterion::Criterion;
+
+fn create_realm(c: &mut Criterion) {
+    c.bench_function("Create Realm", move |b| b.iter(|| Realm::create()));
+}
+
+criterion_group!(benches, create_realm);
+criterion_main!(benches);

--- a/src/bin/shell.rs
+++ b/src/bin/shell.rs
@@ -21,6 +21,7 @@
     clippy::module_name_repetitions
 )]
 
+use boa::realm::Realm;
 use boa::{exec::Executor, forward_val};
 use std::{fs::read_to_string, path::PathBuf};
 use structopt::StructOpt;
@@ -35,8 +36,8 @@ pub fn main() -> Result<(), std::io::Error> {
     let args = Opt::from_args();
 
     let buffer = read_to_string(args.file)?;
-
-    let mut engine = Executor::new();
+    let realm = Realm::create();
+    let mut engine = Executor::new(realm);
 
     match forward_val(&mut engine, &buffer) {
         Ok(v) => print!("{}", v.to_string()),

--- a/src/lib/js/array.rs
+++ b/src/lib/js/array.rs
@@ -290,11 +290,13 @@ pub fn create_constructor(global: &Value) -> Value {
 mod tests {
     use crate::exec::Executor;
     use crate::forward;
+    use crate::realm::Realm;
 
     #[test]
     fn concat() {
         //TODO: array display formatter
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         let empty = new Array();
         let one = new Array(1);
@@ -316,7 +318,8 @@ mod tests {
 
     #[test]
     fn join() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         let empty = [ ];
         let one = ["a"];

--- a/src/lib/js/boolean.rs
+++ b/src/lib/js/boolean.rs
@@ -91,6 +91,7 @@ pub fn this_boolean_value(value: &Value) -> Value {
 mod tests {
     use super::*;
     use crate::exec::Executor;
+    use crate::realm::Realm;
     use crate::{forward, forward_val, js::value::same_value};
 
     #[test]
@@ -103,7 +104,8 @@ mod tests {
     #[test]
     /// Test the correct type is returned from call and construct
     fn construct_and_call() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const one = new Boolean(1);
         const zero = Boolean(0);
@@ -118,7 +120,8 @@ mod tests {
 
     #[test]
     fn constructor_gives_true_instance() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const trueVal = new Boolean(true);
         const trueNum = new Boolean(1);
@@ -147,7 +150,8 @@ mod tests {
 
     #[test]
     fn instances_have_correct_proto_set() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const boolInstance = new Boolean(true);
         const boolProto = Boolean.prototype;

--- a/src/lib/js/function.rs
+++ b/src/lib/js/function.rs
@@ -133,11 +133,13 @@ pub fn create_unmapped_arguments_object(arguments_list: Vec<Value>) -> Value {
 #[cfg(test)]
 mod tests {
     use crate::exec::Executor;
+    use crate::realm::Realm;
     use crate::{forward, forward_val, js::value::from_value};
 
     #[test]
     fn check_arguments_object() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         function jason(a, b) {
             return arguments[0];

--- a/src/lib/js/regexp.rs
+++ b/src/lib/js/regexp.rs
@@ -292,10 +292,12 @@ mod tests {
     use super::*;
     use crate::exec::Executor;
     use crate::forward;
+    use crate::realm::Realm;
 
     #[test]
     fn test_constructors() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         let constructed = new RegExp("[0-9]+(\\.[0-9]+)?");
         let literal = /[0-9]+(\.[0-9]+)?/;
@@ -345,7 +347,8 @@ mod tests {
 
     #[test]
     fn test_last_index() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         let regex = /[0-9]+(\.[0-9]+)?/g;
         "#;
@@ -360,7 +363,8 @@ mod tests {
 
     #[test]
     fn test_exec() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         var re = /quick\s(brown).+?(jumps)/ig;
         var result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
@@ -379,7 +383,8 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
 
         assert_eq!(
             forward(&mut engine, "(new RegExp('a+b+c')).toString()"),

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -713,6 +713,7 @@ pub fn init(global: &Value) {
 mod tests {
     use super::*;
     use crate::exec::Executor;
+    use crate::realm::Realm;
     use crate::{forward, forward_val};
 
     #[test]
@@ -749,7 +750,8 @@ mod tests {
     // }
     #[test]
     fn concat() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const hello = new String('Hello, ');
         const world = new String('world! ');
@@ -766,7 +768,8 @@ mod tests {
     #[test]
     /// Test the correct type is returned from call and construct
     fn construct_and_call() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const hello = new String('Hello');
         const world = String('world');
@@ -781,7 +784,8 @@ mod tests {
 
     #[test]
     fn repeat() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const empty = new String('');
         const en = new String('english');
@@ -808,7 +812,8 @@ mod tests {
 
     #[test]
     fn starts_with() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const empty = new String('');
         const en = new String('english');
@@ -831,7 +836,8 @@ mod tests {
 
     #[test]
     fn ends_with() {
-        let mut engine = Executor::new();
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
         let init = r#"
         const empty = new String('');
         const en = new String('english');

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -36,11 +36,13 @@
 pub mod environment;
 pub mod exec;
 pub mod js;
+pub mod realm;
 pub mod syntax;
 
 use crate::{
     exec::{Executor, Interpreter},
     js::value::ResultValue,
+    realm::Realm,
     syntax::{ast::expr::Expr, lexer::Lexer, parser::Parser},
 };
 use wasm_bindgen::prelude::*;
@@ -76,7 +78,10 @@ pub fn forward_val(engine: &mut Interpreter, src: &str) -> ResultValue {
 
 /// Create a clean Interpreter and execute the code
 pub fn exec(src: &str) -> String {
-    let mut engine: Interpreter = Executor::new();
+    // Create new Realm
+    let realm = Realm::create();
+    realm.create_instrinsics();
+    let mut engine: Interpreter = Executor::new(realm);
     forward(&mut engine, src)
 }
 
@@ -111,8 +116,10 @@ pub fn evaluate(src: &str) -> String {
             return String::from("parsing failed");
         }
     }
-
-    let mut engine: Interpreter = Executor::new();
+    // Create new Realm
+    let realm = Realm::create();
+    realm.create_instrinsics();
+    let mut engine: Interpreter = Executor::new(realm);
     let result = engine.run(&expr);
     log("test2");
     match result {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -80,7 +80,6 @@ pub fn forward_val(engine: &mut Interpreter, src: &str) -> ResultValue {
 pub fn exec(src: &str) -> String {
     // Create new Realm
     let realm = Realm::create();
-    realm.create_instrinsics();
     let mut engine: Interpreter = Executor::new(realm);
     forward(&mut engine, src)
 }
@@ -118,7 +117,6 @@ pub fn evaluate(src: &str) -> String {
     }
     // Create new Realm
     let realm = Realm::create();
-    realm.create_instrinsics();
     let mut engine: Interpreter = Executor::new(realm);
     let result = engine.run(&expr);
     log("test2");

--- a/src/lib/realm.rs
+++ b/src/lib/realm.rs
@@ -1,0 +1,95 @@
+//! Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment,
+//! all of the ECMAScript code that is loaded within the scope of that global environment,
+//! and other associated state and resources.
+//!
+//!A realm is represented in this implementation as a Realm struct with the fields specified from the spec
+use crate::{
+    environment::{
+        declarative_environment_record::DeclarativeEnvironmentRecord,
+        global_environment_record::GlobalEnvironmentRecord,
+        lexical_environment::LexicalEnvironment,
+        object_environment_record::ObjectEnvironmentRecord,
+    },
+    js::{
+        array, boolean, console, function, json, math, object, regexp, string,
+        value::{Value, ValueData},
+    },
+};
+use gc::{Gc, GcCell};
+use std::collections::{hash_map::HashMap, hash_set::HashSet};
+
+/// Representation of a Realm.   
+/// In the specification these are called Realm Records.
+#[derive(Debug)]
+pub struct Realm {
+    pub global_obj: Value,
+    pub global_env: Gc<GcCell<Box<GlobalEnvironmentRecord>>>,
+    pub environment: LexicalEnvironment,
+}
+
+impl Realm {
+    pub fn create() -> Realm {
+        // Create brand new global object
+        // Global has no prototype to pass None to new_obj
+        let global = ValueData::new_obj(None);
+        // We need to clone the global here because its referenced from separate places (only pointer is cloned)
+        let global_env = new_global_environment(global.clone(), global.clone());
+
+        let new_realm = Realm {
+            global_obj: global.clone(),
+            global_env: global_env,
+            environment: LexicalEnvironment::new(global),
+        };
+
+        // Add new builtIns to Realm
+        // At a later date this can be removed from here and called explicity, but for now we almost always want these default builtins
+        new_realm.create_instrinsics();
+
+        new_realm
+    }
+
+    // Sets up the default global objects within Global
+    pub fn create_instrinsics(&self) {
+        let global = &self.global_obj;
+        // Create intrinsics, add global objects here
+        object::init(global);
+        console::init(global);
+        math::init(global);
+        function::init(global);
+        json::init(global);
+
+        global.set_field_slice("String", string::create_constructor(global));
+        global.set_field_slice("RegExp", regexp::create_constructor(global));
+        global.set_field_slice("Array", array::create_constructor(global));
+        global.set_field_slice("Boolean", boolean::create_constructor(global));
+    }
+}
+
+// Similar to new_global_environment in lexical_environment, except we need to return a GlobalEnvirionment
+fn new_global_environment(
+    global: Value,
+    this_value: Value,
+) -> Gc<GcCell<Box<GlobalEnvironmentRecord>>> {
+    let obj_rec = Box::new(ObjectEnvironmentRecord {
+        bindings: global,
+        outer_env: None,
+        /// Object Environment Records created for with statements (13.11)
+        /// can provide their binding object as an implicit this value for use in function calls.
+        /// The capability is controlled by a withEnvironment Boolean value that is associated
+        /// with each object Environment Record. By default, the value of withEnvironment is false
+        /// for any object Environment Record.
+        with_environment: false,
+    });
+
+    let dcl_rec = Box::new(DeclarativeEnvironmentRecord {
+        env_rec: HashMap::new(),
+        outer_env: None,
+    });
+
+    Gc::new(GcCell::new(Box::new(GlobalEnvironmentRecord {
+        object_record: obj_rec,
+        global_this_binding: this_value,
+        declarative_record: dcl_rec,
+        var_names: HashSet::new(),
+    })))
+}

--- a/src/lib/realm.rs
+++ b/src/lib/realm.rs
@@ -49,7 +49,7 @@ impl Realm {
     }
 
     // Sets up the default global objects within Global
-    pub fn create_instrinsics(&self) {
+    fn create_instrinsics(&self) {
         let global = &self.global_obj;
         // Create intrinsics, add global objects here
         object::init(global);

--- a/src/lib/realm.rs
+++ b/src/lib/realm.rs
@@ -37,7 +37,7 @@ impl Realm {
 
         let new_realm = Realm {
             global_obj: global.clone(),
-            global_env: global_env,
+            global_env,
             environment: LexicalEnvironment::new(global),
         };
 


### PR DESCRIPTION
This doesn't fix #119 but it helps with that.
We would still need to add the functionality for boa shell.

This removes InterpreterBuilder and replaces it with `Realm` which is to be inline with the spec