### PR TITLE
String match all fixes #115

### DIFF
--- a/src/lib/js/regexp.rs
+++ b/src/lib/js/regexp.rs
@@ -264,8 +264,8 @@ pub fn match_all(this: &Value, arg_str: String) -> ResultValue {
     let matches: Vec<Value> = this.with_internal_state_ref(|regex: &RegExp| {
         let mut matches = Vec::new();
 
-        'find_loop: for m in regex.matcher.find_iter(&arg_str) {
-            for caps in regex.matcher.captures_iter(&m.as_str()) {
+        for m in regex.matcher.find_iter(&arg_str) {
+            if let Some(caps) = regex.matcher.captures(&m.as_str()) {
                 let match_vec = caps
                     .iter()
                     .map(|group| match group {
@@ -284,7 +284,7 @@ pub fn match_all(this: &Value, arg_str: String) -> ResultValue {
                 matches.push(match_val);
 
                 if !regex.flags.contains('g') {
-                    break 'find_loop;
+                    break;
                 }
             }
         }

--- a/src/lib/js/regexp.rs
+++ b/src/lib/js/regexp.rs
@@ -268,7 +268,10 @@ pub fn match_all(this: &Value, arg_str: String) -> ResultValue {
             for m in regex.matcher.find_iter(&arg_str) {
                 let value = to_value(vec![m.as_str()]);
                 value.set_prop_slice("index", Property::default().value(to_value(m.start())));
-                value.set_prop_slice("input", Property::default().value(to_value(arg_str.clone())));
+                value.set_prop_slice(
+                    "input",
+                    Property::default().value(to_value(arg_str.clone())),
+                );
                 matches.push(value);
             }
         } else {
@@ -280,7 +283,10 @@ pub fn match_all(this: &Value, arg_str: String) -> ResultValue {
                 if let Some((start, end)) = locations.get(0) {
                     let value = to_value(vec![&arg_str[start..end]]);
                     value.set_prop_slice("index", Property::default().value(to_value(m.start())));
-                    value.set_prop_slice("input", Property::default().value(to_value(arg_str.clone())));
+                    value.set_prop_slice(
+                        "input",
+                        Property::default().value(to_value(arg_str.clone())),
+                    );
                     matches.push(value);
                 } else {
                     matches.push(Gc::new(ValueData::Undefined));

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -4,7 +4,7 @@ use crate::{
         function::NativeFunctionData,
         object::{Object, ObjectKind, PROTOTYPE},
         property::Property,
-        regexp::{make_regexp, r#match as regexp_match, match_all as regexp_match_all},
+        regexp::{make_regexp, match_all as regexp_match_all, r#match as regexp_match},
         value::{from_value, to_value, ResultValue, Value, ValueData},
     },
 };

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -669,16 +669,20 @@ pub fn match_all(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultV
     let val: Value = to_value(ctx.value_to_rust_string(this));
     let regexp: Value = match args.get(0) {
         Some(arg) => from_value(arg.clone()).map_err(to_value),
-        None => make_regexp(&to_value(Object::default()), &[to_value(String::from(""))], ctx),
+        None => make_regexp(
+            &to_value(Object::default()),
+            &[to_value(String::from("(?:)")), to_value(String::from("g"))],
+            ctx
+        ),
     }?.clone();
 
     let mut matches: Vec<Value> = Vec::new();
-    let null = Gc::new(ValueData::Null);
+    let js_null = Gc::new(ValueData::Null);
 
     loop {
         match exec_regex(&regexp, &[val.clone()], ctx) {
             Ok(result) => {
-                if result != null {
+                if result != js_null {
                     matches.push(result.clone());
                 } else {
                     break;

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -918,6 +918,39 @@ mod tests {
             String::from("2")
         );
 
+        forward(
+            &mut engine,
+            "const groupMatches = 'test1test2'.matchAll(/t(e)(st(\\d?))/g)",
+        );
+        assert_eq!(
+            forward(&mut engine, "groupMatches.length"),
+            String::from("2")
+        );
+        assert_eq!(
+            forward(&mut engine, "groupMatches[0][1]"),
+            String::from("e")
+        );
+        assert_eq!(
+            forward(&mut engine, "groupMatches[0][2]"),
+            String::from("st1")
+        );
+        assert_eq!(
+            forward(&mut engine, "groupMatches[0][3]"),
+            String::from("1")
+        );
+        assert_eq!(
+            forward(&mut engine, "groupMatches[1][3]"),
+            String::from("2")
+        );
+
+        assert_eq!(
+            forward(
+                &mut engine,
+                "'test1test2'.matchAll(/t(e)(st(\\d?))/).length"
+            ),
+            String::from("1")
+        );
+
         let init = r#"
         const regexp = RegExp('foo[a-z]*','g');
         const str = 'table football, foosball';

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -5,6 +5,8 @@ use crate::{
         object::{Object, ObjectKind, PROTOTYPE},
         property::Property,
         value::{from_value, to_value, ResultValue, Value, ValueData},
+        regexp::{make_regexp, exec as exec_regex},
+        array::{make_array, push as push_to_array},
     },
 };
 use gc::Gc;
@@ -661,6 +663,38 @@ pub fn value_of(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultVa
     to_string(this, args, ctx)
 }
 
+/// Returns an iterator of all results matching a string against a regular expression, including capturing groups
+/// <https://tc39.es/ecma262/#sec-string.prototype.matchall>
+pub fn match_all(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    let val: Value = to_value(ctx.value_to_rust_string(this));
+    let regexp: Value = match args.get(0) {
+        Some(arg) => from_value(arg.clone()).map_err(to_value),
+        None => make_regexp(&to_value(Object::default()), &[to_value(String::from(""))], ctx),
+    }?.clone();
+
+    let mut matches: Vec<Value> = Vec::new();
+    let null = Gc::new(ValueData::Null);
+
+    loop {
+        match exec_regex(&regexp, &[val.clone()], ctx) {
+            Ok(result) => {
+                if result != null {
+                    matches.push(result.clone());
+                } else {
+                    break;
+                }
+            },
+            Err(e) => return Err(e),
+        };
+    }
+
+
+    let arr = make_array(&to_value(Object::default()), &[], ctx)?;
+    push_to_array(&arr, &matches[..], ctx)?;
+
+    Ok(to_value(arr))
+}
+
 /// Create a new `String` object
 pub fn create_constructor(global: &Value) -> Value {
     // Create constructor function object
@@ -697,6 +731,7 @@ pub fn create_constructor(global: &Value) -> Value {
     proto.set_field_slice("substring", to_value(substring as NativeFunctionData));
     proto.set_field_slice("substr", to_value(substr as NativeFunctionData));
     proto.set_field_slice("valueOf", to_value(value_of as NativeFunctionData));
+    proto.set_field_slice("matchAll", to_value(match_all as NativeFunctionData));
 
     let string = to_value(string_constructor);
     proto.set_field_slice("constructor", string.clone());
@@ -856,5 +891,24 @@ mod tests {
         assert_eq!(forward(&mut engine, "emptyLiteral.endsWith('')"), pass);
         assert_eq!(forward(&mut engine, "enLiteral.endsWith('h')"), pass);
         assert_eq!(forward(&mut engine, "zhLiteral.endsWith('文')"), pass);
+    }
+
+    #[test]
+    fn match_all() {
+        let realm = Realm::create();
+        let mut engine = Executor::new(realm);
+        let init = r#"
+        const regexp = RegExp('[a-c]','');
+        const str = 'abc';
+        const result = str.matchAll(regexp);
+        "#;
+        forward(&mut engine, init);
+
+        println!("{:?}", forward(&mut engine, "[['a']]"));
+        println!("{:?}", forward(&mut engine, "result;"));
+        println!("{:?}", forward(&mut engine, "result.length;"));
+
+        assert!(false);
+        // assert_eq!(forward(&mut engine, "result;"), forward(&mut engine, "['a']"));
     }
 }

--- a/src/lib/js/string.rs
+++ b/src/lib/js/string.rs
@@ -668,7 +668,6 @@ pub fn value_of(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultVa
 pub fn match_all(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
     let re: Value = match args.get(0) {
         Some(arg) => if arg == &Gc::new(ValueData::Null) {
-            // TODO: should null be converted to string?
             make_regexp(
                 &to_value(Object::default()),
                 &[to_value(ctx.value_to_rust_string(arg)), to_value(String::from("g"))],


### PR DESCRIPTION
Implementation for #115.

Since `matchAll` is [part of RegExp prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll), and `String` objecti is calling it internally, I tried to follow that with my implementation.

There is still some work needed for `matchAll` to be finished. The method should return a JS iterator, but with this implementation it's returning an array. From what I understand, we don't have iterators implemented yet. 