### PR TITLE
Fix early return

### DIFF
--- a/src/lib/environment/lexical_environment.rs
+++ b/src/lib/environment/lexical_environment.rs
@@ -95,8 +95,8 @@ impl LexicalEnvironment {
         self.environment_stack.push_back(env);
     }
 
-    pub fn pop(&mut self) {
-        self.environment_stack.pop_back();
+    pub fn pop(&mut self) -> Option<Environment> {
+        self.environment_stack.pop_back()
     }
 
     pub fn environments(&self) -> impl Iterator<Item = Environment> {

--- a/src/lib/exec.rs
+++ b/src/lib/exec.rs
@@ -95,6 +95,7 @@ impl Executor for Interpreter {
 
                 // pop the block env
                 let block_env = self.realm.environment.pop();
+
                 // clear the early return flag `self.is_return`
                 // only when we leave the associated function
                 if let Some(env) = block_env {

--- a/src/lib/exec.rs
+++ b/src/lib/exec.rs
@@ -98,9 +98,8 @@ impl Executor for Interpreter {
                 // clear the early return flag `self.is_return`
                 // only when we leave the associated function
                 if let Some(env) = block_env {
-                    match env.deref().borrow().get_environment_type() {
-                        EnvironmentType::Function => self.is_return = false,
-                        _ => {}
+                    if let EnvironmentType::Function = env.deref().borrow().get_environment_type() {
+                        self.is_return = false;
                     }
                 }
                 Ok(obj)


### PR DESCRIPTION
This PR fixes https://github.com/jasonwilliams/boa/issues/195

Currently the `Interpreter` handles early returns by setting an `is_return` flag when it reaches a return expression. When executing a block expression, the interpreter will skip any sub-expressions if the flag is set, and then unset it.

This bug occurred when the return expression was located inside a block nested in the function's one,
to fix this, this PR unset the `is_return` flag only when leaving the "root block" of a function.
I used the EnvironementType of the block environment to identify such "root blocks".

I hope this helps