### PR TITLE
Fixed array creation bug in `Array.slice` implementation

### DIFF
--- a/src/lib/environment/lexical_environment.rs
+++ b/src/lib/environment/lexical_environment.rs
@@ -207,7 +207,7 @@ impl LexicalEnvironment {
             .any(|env| env.borrow().has_binding(name))
     }
 
-    pub fn get_binding_value(&mut self, name: &str) -> Value {
+    pub fn get_binding_value(&self, name: &str) -> Value {
         self.environments()
             .find(|env| env.borrow().has_binding(name))
             .map(|env| env.borrow().get_binding_value(name, false))


### PR DESCRIPTION
This PR fixes a bug introduced in #180 . While creating array, we need to set it's prototype as well. 

A helper function `new_array` is added and all usages have been replaced.  