### PR TITLE
[lexer: single-line-comment] Fix bug when single line comment is last line of file 

### DIFF
--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -153,8 +153,7 @@ impl<'a> Lexer<'a> {
     /// read_line attempts to read until the end of the line and returns the String object or a LexerError
     fn read_line(&mut self) -> Result<String, LexerError> {
         let mut buf = String::new();
-        loop {
-            if self.preview_next().is_none() {break;}
+        while self.preview_next().is_some() {
             let ch = self.next()?;
             match ch {
                 _ if ch.is_ascii_control() => {

--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -154,6 +154,7 @@ impl<'a> Lexer<'a> {
     fn read_line(&mut self) -> Result<String, LexerError> {
         let mut buf = String::new();
         loop {
+            if self.preview_next().is_none() {break;}
             let ch = self.next()?;
             match ch {
                 _ if ch.is_ascii_control() => {


### PR DESCRIPTION
Fixes #221