### PR TITLE
Fix lexing of "0_" token

### DIFF
--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -323,7 +323,6 @@ impl<'a> Lexer<'a> {
                 '0' => {
                     let mut buf = String::new();
                     let ch = self.preview_next();
-                    
                     if ch.is_none() {self.push_token(TokenData::NumericLiteral(0 as f64));}
                     let ch = self.next();
                     let num = match ch {

--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -198,8 +198,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn check_after_numeric_literal(&mut self) -> Result<(), LexerError> {
-        let ch = self.preview_next();
-        match ch {
+        match self.preview_next() {
             Some(ch)
                 if ch.is_ascii_alphabetic() || ch == '$' || ch == '_' || ch.is_ascii_digit() =>
             {

--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -408,9 +408,8 @@ impl<'a> Lexer<'a> {
                     self.push_token(TokenData::NumericLiteral(num as f64));
 
                     //11.8.3
-                    match self.check_after_numeric_literal() {
-                        Ok(_) => (),
-                        Err(e) => return Err(e),
+                    if let Err(e) = self.check_after_numeric_literal() {
+                        return Err(e)
                     };
                 }
                 _ if ch.is_digit(10) => {

--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -324,8 +324,7 @@ impl<'a> Lexer<'a> {
                     let mut buf = String::new();
                     let ch = self.preview_next();
                     if ch.is_none() {self.push_token(TokenData::NumericLiteral(0 as f64));}
-                    let ch = self.next();
-                    let num = match ch {
+                    let num = match self.next() {
                         'x' | 'X' => {
                             while let Some(ch) = self.preview_next() {
                                 if ch.is_digit(16) {
@@ -392,7 +391,7 @@ impl<'a> Lexer<'a> {
                     let ch = self.preview_next();
                     match ch {
                         Some(ch) if ch.is_ascii_alphabetic() || ch == '$' || ch == '_' || ch.is_ascii_digit() => {
-                            return Err(LexerError::new("After NumericLiteral must not occur IdentifierStart nor DecimalDigit"));
+                            return Err(LexerError::new("NumericLiteral token must not be followed by IdentifierStart nor DecimalDigit characters"));
                         }
                         Some(_) => {}
                         None => {}

--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -197,6 +197,18 @@ impl<'a> Lexer<'a> {
         result
     }
 
+    fn read_integer_in_base(&mut self, base: u32, mut buf: String) -> u64 {
+        self.next();
+        while let Some(ch) = self.preview_next() {
+            if ch.is_digit(base) {
+                buf.push(self.next());
+            } else {
+                break;
+            }
+        }
+        u64::from_str_radix(&buf, base).expect("Could not convert value to u64")
+    }
+
     fn check_after_numeric_literal(&mut self) -> Result<(), LexerError> {
         match self.preview_next() {
             Some(ch)
@@ -341,37 +353,13 @@ impl<'a> Lexer<'a> {
                             return Ok(());
                         }
                         Some('x') | Some('X') => {
-                            self.next();
-                            while let Some(ch) = self.preview_next() {
-                                if ch.is_digit(16) {
-                                    buf.push(self.next());
-                                } else {
-                                    break;
-                                }
-                            }
-                            u64::from_str_radix(&buf, 16).expect("Could not convert value to u64")
+                            self.read_integer_in_base(16, buf)
                         }
                         Some('o') | Some('O') => {
-                            self.next();
-                            while let Some(ch) = self.preview_next() {
-                                if ch.is_digit(8) {
-                                    buf.push(self.next());
-                                } else {
-                                    break;
-                                }
-                            }
-                            u64::from_str_radix(&buf, 8).expect("Could not convert value to u64")
+                            self.read_integer_in_base(8, buf)
                         }
                         Some('b') | Some('B') => {
-                            self.next();
-                            while let Some(ch) = self.preview_next() {
-                                if ch.is_digit(2) {
-                                    buf.push(self.next());
-                                } else {
-                                    break;
-                                }
-                            }
-                            u64::from_str_radix(&buf, 2).expect("Could not convert value to u64")
+                            self.read_integer_in_base(2, buf)
                         }
                         Some(ch) if ch.is_ascii_digit() => {
                             // LEGACY OCTAL (ONLY FOR NON-STRICT MODE)


### PR DESCRIPTION
Several changes regarding 0_ token.
- preview_next None check before analyzing the x,b,o token (because it can be end of stream)
- Addition of 0X and 0B along with 0x 0b.
- replace of if/else with match
- commenting-out non-strict legacy octal token, which errors out in strict mode
- previous bullet will error out on the last part added which is 11.8.3 clause from spec