### PR TITLE
Fixed compilation without "wasm-bindgen" feature

### DIFF
--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -1,25 +1,6 @@
-#![forbid(
-    warnings,
-    anonymous_parameters,
-    unused_extern_crates,
-    unused_import_braces,
-    missing_copy_implementations,
-    //trivial_casts,
-    variant_size_differences,
-    missing_debug_implementations,
-    trivial_numeric_casts
-)]
-// Debug trait derivation will show an error if forbidden.
-#![deny(unused_qualifications, unsafe_code)]
-#![deny(clippy::all)]
-#![warn(clippy::pedantic)]
-#![allow(
-    missing_docs,
-    clippy::many_single_char_names,
-    clippy::unreadable_literal,
-    clippy::excessive_precision,
-    clippy::module_name_repetitions
-)]
+#![deny(unused_qualifications, clippy::correctness, clippy::style)]
+#![warn(clippy::perf)]
+#![allow(clippy::cognitive_complexity)]
 
 use boa::exec;
 use std::{env, fs::read_to_string, process::exit};

--- a/src/bin/shell.rs
+++ b/src/bin/shell.rs
@@ -1,25 +1,6 @@
-#![forbid(
-    warnings,
-    anonymous_parameters,
-    unused_extern_crates,
-    unused_import_braces,
-    missing_copy_implementations,
-    //trivial_casts,
-    variant_size_differences,
-    missing_debug_implementations,
-    trivial_numeric_casts
-)]
-// Debug trait derivation will show an error if forbidden.
-#![deny(unused_qualifications, unsafe_code)]
-#![deny(clippy::all)]
-#![warn(clippy::pedantic)]
-#![allow(
-    missing_docs,
-    clippy::many_single_char_names,
-    clippy::unreadable_literal,
-    clippy::excessive_precision,
-    clippy::module_name_repetitions
-)]
+#![deny(unused_qualifications, clippy::correctness, clippy::style)]
+#![warn(clippy::perf)]
+#![allow(clippy::cognitive_complexity)]
 
 use boa::realm::Realm;
 use boa::{exec::Executor, forward_val};

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -7,6 +7,8 @@ pub mod environment;
 pub mod exec;
 pub mod realm;
 pub mod syntax;
+#[cfg(feature = "wasm-bindgen")]
+mod wasm;
 
 use crate::{
     builtins::value::ResultValue,
@@ -14,7 +16,8 @@ use crate::{
     realm::Realm,
     syntax::{ast::expr::Expr, lexer::Lexer, parser::Parser},
 };
-use wasm_bindgen::prelude::*;
+#[cfg(feature = "wasm-bindgen")]
+pub use wasm::*;
 
 fn parser_expr(src: &str) -> Expr {
     let mut lexer = Lexer::new(src);
@@ -51,45 +54,4 @@ pub fn exec(src: &str) -> String {
     let realm = Realm::create();
     let mut engine: Interpreter = Executor::new(realm);
     forward(&mut engine, src)
-}
-
-// WASM
-#[wasm_bindgen]
-extern "C" {
-    // Use `js_namespace` here to bind `console.log(..)` instead of just
-    // `log(..)`
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-
-#[wasm_bindgen]
-pub fn evaluate(src: &str) -> String {
-    let mut lexer = Lexer::new(&src);
-    match lexer.lex() {
-        Ok(_v) => (),
-        Err(v) => log(&v.to_string()),
-    }
-
-    let tokens = lexer.tokens;
-
-    // Setup executor
-    let expr: Expr;
-
-    match Parser::new(tokens).parse_all() {
-        Ok(v) => {
-            expr = v;
-        }
-        Err(_v) => {
-            log("parsing fail");
-            return String::from("parsing failed");
-        }
-    }
-    // Create new Realm
-    let realm = Realm::create();
-    let mut engine: Interpreter = Executor::new(realm);
-    let result = engine.run(&expr);
-    match result {
-        Ok(v) => v.to_string(),
-        Err(v) => format!("{}: {}", "error", v.to_string()),
-    }
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,4 +1,3 @@
-// Debug trait derivation will show an error if forbidden.
 #![deny(unused_qualifications, clippy::correctness, clippy::style)]
 #![warn(clippy::perf)]
 #![allow(clippy::cognitive_complexity)]

--- a/src/lib/wasm.rs
+++ b/src/lib/wasm.rs
@@ -1,0 +1,47 @@
+use crate::{
+    exec::{Executor, Interpreter},
+    realm::Realm,
+    syntax::{ast::expr::Expr, lexer::Lexer, parser::Parser},
+};
+use wasm_bindgen::prelude::*;
+
+// WASM
+#[wasm_bindgen]
+extern "C" {
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn evaluate(src: &str) -> String {
+    let mut lexer = Lexer::new(&src);
+    match lexer.lex() {
+        Ok(_v) => (),
+        Err(v) => log(&v.to_string()),
+    }
+
+    let tokens = lexer.tokens;
+
+    // Setup executor
+    let expr: Expr;
+
+    match Parser::new(tokens).parse_all() {
+        Ok(v) => {
+            expr = v;
+        }
+        Err(_v) => {
+            log("parsing fail");
+            return String::from("parsing failed");
+        }
+    }
+    // Create new Realm
+    let realm = Realm::create();
+    let mut engine: Interpreter = Executor::new(realm);
+    let result = engine.run(&expr);
+    match result {
+        Ok(v) => v.to_string(),
+        Err(v) => format!("{}: {}", "error", v.to_string()),
+    }
+}


### PR DESCRIPTION
Fixes #234. I put the wasm-related stuff in its own module. I also conditionally re-exported the contents of this module, as the `evaluate` function is public and I was unsure if making it private would break semver.