### PR TITLE
Made "structopt" dependency optional under "cli" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2018"
 default-run = "boa"
 
 [features]
-default = ["wasm-bindgen"]
+default = ["wasm-bindgen", "cli"]
+cli = ["structopt"]
 
 [dependencies]
 gc = "^0.3.3"
@@ -20,10 +21,10 @@ gc_derive = "^0.3.2"
 serde_json = "^1.0.40"
 rand = "^0.7.0"
 regex = "^1.3.0"
-structopt = "0.3.2"
 
 # Optional Dependencies
 wasm-bindgen = { version = "^0.2.50", optional = true }
+structopt = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 criterion = "^0.3.0"
@@ -59,3 +60,4 @@ bench = false
 name = "boashell"
 path = "src/bin/shell.rs"
 bench = false
+required-features = ["cli"]


### PR DESCRIPTION
I made structopt optional and put it under a "cli" feature. I left it on by default, so users have to turn off default features to deactivate it. I believe this also makes it so no changes are needed when running the binary.

Resolves #239 