### PR TITLE
Fixed parsing of floats with scientific notation

### DIFF
--- a/src/lib/syntax/lexer.rs
+++ b/src/lib/syntax/lexer.rs
@@ -1016,7 +1016,9 @@ mod tests {
 
     #[test]
     fn numbers() {
-        let mut lexer = Lexer::new("1 2 0x34 056 7.89 42. 5e3 5e+3 5e-3 0b10 0O123 0999");
+        let mut lexer = Lexer::new(
+            "1 2 0x34 056 7.89 42. 5e3 5e+3 5e-3 0b10 0O123 0999 1.0e1 1.0e-1 1.0E1 1E1",
+        );
         lexer.lex().expect("failed to lex");
         assert_eq!(lexer.tokens[0].data, TokenData::NumericLiteral(1.0));
         assert_eq!(lexer.tokens[1].data, TokenData::NumericLiteral(2.0));
@@ -1030,6 +1032,10 @@ mod tests {
         assert_eq!(lexer.tokens[9].data, TokenData::NumericLiteral(2.0));
         assert_eq!(lexer.tokens[10].data, TokenData::NumericLiteral(83.0));
         assert_eq!(lexer.tokens[11].data, TokenData::NumericLiteral(999.0));
+        assert_eq!(lexer.tokens[12].data, TokenData::NumericLiteral(10.0));
+        assert_eq!(lexer.tokens[13].data, TokenData::NumericLiteral(0.1));
+        assert_eq!(lexer.tokens[14].data, TokenData::NumericLiteral(10.0));
+        assert_eq!(lexer.tokens[14].data, TokenData::NumericLiteral(10.0));
     }
 
     #[test]
@@ -1121,35 +1127,5 @@ mod tests {
             lexer.tokens[2].data,
             TokenData::NumericLiteral(100_000_000_000.0)
         );
-    }
-
-    #[test]
-    fn test_positive_float_positive_scientific_notaion() {
-        let mut lexer = Lexer::new("1.0e1");
-        lexer.lex().expect("failed to lex");
-        assert_eq!(lexer.tokens[0].data, TokenData::NumericLiteral(10.0));
-    }
-
-    #[test]
-    fn test_negative_float_positive_scientific_notaion() {
-        let mut lexer = Lexer::new("-1.0e1");
-        lexer.lex().expect("failed to lex");
-        assert_eq!(lexer.tokens[0].data, TokenData::Punctuator(Punctuator::Sub));
-        assert_eq!(lexer.tokens[1].data, TokenData::NumericLiteral(10.0));
-    }
-
-    #[test]
-    fn test_positive_float_negative_scientific_notaion() {
-        let mut lexer = Lexer::new("1.0e-1");
-        lexer.lex().expect("failed to lex");
-        assert_eq!(lexer.tokens[0].data, TokenData::NumericLiteral(0.1));
-    }
-
-    #[test]
-    fn test_negative_float_negative_scientific_notaion() {
-        let mut lexer = Lexer::new("-1.0e-1");
-        lexer.lex().expect("failed to lex");
-        assert_eq!(lexer.tokens[0].data, TokenData::Punctuator(Punctuator::Sub));
-        assert_eq!(lexer.tokens[1].data, TokenData::NumericLiteral(0.1));
     }
 }


### PR DESCRIPTION
Fixes scientific notation with floats. Resolves #204 