### PR TITLE
Refactor old function with new function object

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,16 +7,14 @@
       "type": "process",
       "label": "Cargo Run",
       "command": "cargo",
-      "args": [
-        "run",
-        "./tests/js/test.js"
-      ],
-      "problemMatcher": [
-        "$rustc"
-      ],
+      "args": ["run", "./tests/js/test.js"],
+      "problemMatcher": ["$rustc"],
       "group": {
         "kind": "build",
         "isDefault": true
+      },
+      "options": {
+        "env": { "RUST_BACKTRACE": "full" }
       },
       "presentation": {
         "clear": true
@@ -26,19 +24,9 @@
       "type": "process",
       "label": "Get Tokens",
       "command": "cargo",
-      "args": [
-        "run",
-        "--",
-        "-t=Debug",
-        "./tests/js/test.js"
-      ],
-      "problemMatcher": [
-        "$rustc"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
+      "args": ["run", "--", "-t=Debug", "./tests/js/test.js"],
+      "problemMatcher": ["$rustc"],
+      "group": "build",
       "presentation": {
         "clear": true
       }
@@ -47,19 +35,9 @@
       "type": "process",
       "label": "Get AST",
       "command": "cargo",
-      "args": [
-        "run",
-        "--",
-        "-a=Debug",
-        "./tests/js/test.js"
-      ],
-      "problemMatcher": [
-        "$rustc"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
+      "args": ["run", "--", "-a=Debug", "./tests/js/test.js"],
+      "problemMatcher": ["$rustc"],
+      "group": "build",
       "presentation": {
         "clear": true
       }
@@ -68,12 +46,8 @@
       "type": "process",
       "label": "Cargo Test",
       "command": "cargo",
-      "args": [
-        "test"
-      ],
-      "problemMatcher": [
-        "$rustc"
-      ],
+      "args": ["test"],
+      "problemMatcher": ["$rustc"],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -86,17 +60,9 @@
       "type": "process",
       "label": "Cargo Test Build",
       "command": "cargo",
-      "args": [
-        "test",
-        "--no-run"
-      ],
-      "problemMatcher": [
-        "$rustc"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
+      "args": ["test", "--no-run"],
+      "problemMatcher": ["$rustc"],
+      "group": "build"
     }
   ]
 }

--- a/boa/benches/exec.rs
+++ b/boa/benches/exec.rs
@@ -26,29 +26,30 @@ fn symbol_creation(c: &mut Criterion) {
     });
 }
 
-static FOR_LOOP: &str = r#"
-let a = 10;
-let b = "hello";
-for (;;) {
-    a += 5;
+// TODO: implement for loops.
+// static FOR_LOOP: &str = r#"
+// let a = 10;
+// let b = "hello";
+// for (;;) {
+//     a += 5;
 
-    if a < 50 {
-        b += "world";
-    }
+//     if (a < 50) {
+//         b += "world";
+//     }
 
-    if (a > 100) {
-        break;
-    }
-}
-let c = a;
-let d = b;
-"#;
+//     if (a > 100) {
+//         break;
+//     }
+// }
+// let c = a;
+// let d = b;
+// "#;
 
-fn for_loop_execution(c: &mut Criterion) {
-    c.bench_function("For loop (Execution)", move |b| {
-        b.iter(|| exec(black_box(FOR_LOOP)))
-    });
-}
+// fn for_loop_execution(c: &mut Criterion) {
+//     c.bench_function("For loop (Execution)", move |b| {
+//         b.iter(|| exec(black_box(FOR_LOOP)))
+//     });
+// }
 
 static FIBONACCI: &str = r#"
 let num = 12;
@@ -73,7 +74,7 @@ criterion_group!(
     execution,
     create_realm,
     symbol_creation,
-    for_loop_execution,
+    // for_loop_execution,
     fibonacci
 );
 criterion_main!(execution);

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -14,7 +14,6 @@ mod tests;
 
 use crate::{
     builtins::{
-        function::NativeFunctionData,
         object::{internal_methods_trait::ObjectInternalMethods, Object, ObjectKind, PROTOTYPE},
         value::{to_value, ResultValue, Value, ValueData},
     },
@@ -23,7 +22,7 @@ use crate::{
 use std::{borrow::Borrow, ops::Deref};
 
 /// Create a new boolean object - [[Construct]]
-pub fn construct_boolean(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn construct_boolean(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.set_kind(ObjectKind::Boolean);
 
     // Get the argument, if any
@@ -38,7 +37,7 @@ pub fn construct_boolean(this: &Value, args: &[Value], _: &mut Interpreter) -> R
 }
 
 /// Return a boolean literal [[Call]]
-pub fn call_boolean(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn call_boolean(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     // Get the argument, if any
     match args.get(0) {
         Some(ref value) => Ok(to_boolean(value)),
@@ -54,7 +53,7 @@ pub fn call_boolean(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultVal
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-boolean-object
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString
-pub fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn to_string(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     let b = this_boolean_value(this);
     Ok(to_value(b.to_string()))
 }
@@ -67,16 +66,12 @@ pub fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue 
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-boolean.prototype.valueof
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
-pub fn value_of(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn value_of(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(this_boolean_value(this))
 }
 
 /// Create a new `Boolean` object
 pub fn create_constructor(global: &Value) -> Value {
-    let mut boolean = Object::default();
-    boolean.kind = ObjectKind::Function;
-    boolean.set_internal_method("construct", construct_boolean);
-    boolean.set_internal_method("call", call_boolean);
     // Create Prototype
     // https://tc39.es/ecma262/#sec-properties-of-the-boolean-prototype-object
     let boolean_prototype = ValueData::new_obj(Some(global));
@@ -84,10 +79,7 @@ pub fn create_constructor(global: &Value) -> Value {
     make_builtin_fn!(to_string, named "toString", of boolean_prototype);
     make_builtin_fn!(value_of, named "valueOf", of boolean_prototype);
 
-    let boolean_value = to_value(boolean);
-    boolean_prototype.set_field_slice("constructor", to_value(boolean_value.clone()));
-    boolean_value.set_field_slice(PROTOTYPE, boolean_prototype);
-    boolean_value
+    make_constructor_fn!(construct_boolean, call_boolean, global, boolean_prototype)
 }
 
 // === Utility Functions ===

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -18,7 +18,6 @@ mod tests;
 
 use crate::{
     builtins::{
-        function::NativeFunctionData,
         object::InternalState,
         value::{display_obj, from_value, to_value, FromValue, ResultValue, Value, ValueData},
     },
@@ -37,7 +36,7 @@ pub struct ConsoleState {
 
 impl ConsoleState {
     fn new() -> Self {
-        ConsoleState {
+        Self {
             count_map: HashMap::new(),
             timer_map: HashMap::new(),
             groups: vec![],
@@ -149,7 +148,7 @@ pub fn formatter(data: &[Value]) -> String {
 ///
 /// [spec]: https://console.spec.whatwg.org/#assert
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert
-pub fn assert(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn assert(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let assertion = get_arg_at_index::<bool>(args, 0).unwrap_or_default();
 
     if !assertion {
@@ -182,7 +181,7 @@ pub fn assert(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue 
 ///
 /// [spec]: https://console.spec.whatwg.org/#clear
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/clear
-pub fn clear(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn clear(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_mut(|state: &mut ConsoleState| {
         state.groups.clear();
     });
@@ -200,7 +199,7 @@ pub fn clear(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#debug
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/debug
-pub fn debug(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn debug(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_ref(|state| logger(LogMessage::Log(formatter(&args[..])), state));
     Ok(Gc::new(ValueData::Undefined))
 }
@@ -215,7 +214,7 @@ pub fn debug(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#error
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/error
-pub fn error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn error(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_ref(|state| logger(LogMessage::Error(formatter(&args[..])), state));
     Ok(Gc::new(ValueData::Undefined))
 }
@@ -230,7 +229,7 @@ pub fn error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#info
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/info
-pub fn info(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn info(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_ref(|state| logger(LogMessage::Info(formatter(&args[..])), state));
     Ok(Gc::new(ValueData::Undefined))
 }
@@ -245,7 +244,7 @@ pub fn info(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#log
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/log
-pub fn log(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn log(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_ref(|state| logger(LogMessage::Log(formatter(&args[..])), state));
     Ok(Gc::new(ValueData::Undefined))
 }
@@ -260,7 +259,7 @@ pub fn log(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#trace
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/trace
-pub fn trace(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn trace(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     if !args.is_empty() {
         this.with_internal_state_ref(|state| logger(LogMessage::Log(formatter(&args[..])), state));
 
@@ -286,7 +285,7 @@ pub fn trace(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#warn
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/warn
-pub fn warn(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn warn(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_ref(|state| logger(LogMessage::Warn(formatter(&args[..])), state));
     Ok(Gc::new(ValueData::Undefined))
 }
@@ -301,7 +300,7 @@ pub fn warn(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#count
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/count
-pub fn count(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn count(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let label = get_arg_at_index::<String>(args, 0).unwrap_or_else(|| "default".to_string());
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -325,7 +324,7 @@ pub fn count(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#countreset
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/countReset
-pub fn count_reset(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn count_reset(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let label = get_arg_at_index::<String>(args, 0).unwrap_or_else(|| "default".to_string());
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -355,7 +354,7 @@ fn system_time_in_ms() -> u128 {
 ///
 /// [spec]: https://console.spec.whatwg.org/#time
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/time
-pub fn time(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn time(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let label = get_arg_at_index::<String>(args, 0).unwrap_or_else(|| "default".to_string());
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -383,7 +382,7 @@ pub fn time(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#timelog
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/timeLog
-pub fn time_log(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn time_log(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let label = get_arg_at_index::<String>(args, 0).unwrap_or_else(|| "default".to_string());
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -415,7 +414,7 @@ pub fn time_log(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValu
 ///
 /// [spec]: https://console.spec.whatwg.org/#timeend
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/timeEnd
-pub fn time_end(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn time_end(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let label = get_arg_at_index::<String>(args, 0).unwrap_or_else(|| "default".to_string());
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -446,7 +445,7 @@ pub fn time_end(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValu
 ///
 /// [spec]: https://console.spec.whatwg.org/#group
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/group
-pub fn group(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn group(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let group_label = formatter(args);
 
     this.with_internal_state_mut(|state: &mut ConsoleState| {
@@ -467,7 +466,7 @@ pub fn group(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://console.spec.whatwg.org/#groupend
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/groupEnd
-pub fn group_end(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn group_end(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_mut(|state: &mut ConsoleState| {
         state.groups.pop();
     });
@@ -485,7 +484,7 @@ pub fn group_end(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue 
 ///
 /// [spec]: https://console.spec.whatwg.org/#dir
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/dir
-pub fn dir(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn dir(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     this.with_internal_state_mut(|state: &mut ConsoleState| {
         logger(
             LogMessage::Info(display_obj(
@@ -502,25 +501,25 @@ pub fn dir(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 /// Create a new `console` object
 pub fn create_constructor(global: &Value) -> Value {
     let console = ValueData::new_obj(Some(global));
-    console.set_field_slice("assert", to_value(assert as NativeFunctionData));
-    console.set_field_slice("clear", to_value(clear as NativeFunctionData));
-    console.set_field_slice("debug", to_value(debug as NativeFunctionData));
-    console.set_field_slice("error", to_value(error as NativeFunctionData));
-    console.set_field_slice("info", to_value(info as NativeFunctionData));
-    console.set_field_slice("log", to_value(log as NativeFunctionData));
-    console.set_field_slice("trace", to_value(trace as NativeFunctionData));
-    console.set_field_slice("warn", to_value(warn as NativeFunctionData));
-    console.set_field_slice("exception", to_value(error as NativeFunctionData));
-    console.set_field_slice("count", to_value(count as NativeFunctionData));
-    console.set_field_slice("countReset", to_value(count_reset as NativeFunctionData));
-    console.set_field_slice("group", to_value(group as NativeFunctionData));
-    console.set_field_slice("groupCollapsed", to_value(group as NativeFunctionData));
-    console.set_field_slice("groupEnd", to_value(group_end as NativeFunctionData));
-    console.set_field_slice("time", to_value(time as NativeFunctionData));
-    console.set_field_slice("timeLog", to_value(time_log as NativeFunctionData));
-    console.set_field_slice("timeEnd", to_value(time_end as NativeFunctionData));
-    console.set_field_slice("dir", to_value(dir as NativeFunctionData));
-    console.set_field_slice("dirxml", to_value(dir as NativeFunctionData));
+    make_builtin_fn!(assert, named "assert", of console);
+    make_builtin_fn!(clear, named "clear", of console);
+    make_builtin_fn!(debug, named "debug", of console);
+    make_builtin_fn!(error, named "error", of console);
+    make_builtin_fn!(info, named "info", of console);
+    make_builtin_fn!(log, named "log", of console);
+    make_builtin_fn!(trace, named "trace", of console);
+    make_builtin_fn!(warn, named "warn", of console);
+    make_builtin_fn!(error, named "exception", of console);
+    make_builtin_fn!(count, named "count", of console);
+    make_builtin_fn!(count_reset, named "countReset", of console);
+    make_builtin_fn!(group, named "group", of console);
+    make_builtin_fn!(group, named "groupCollapsed", of console);
+    make_builtin_fn!(group_end , named "groupEnd", of console);
+    make_builtin_fn!(time, named "time", of console);
+    make_builtin_fn!(time_log, named "timeLog", of console);
+    make_builtin_fn!(time_end, named "timeEnd", of console);
+    make_builtin_fn!(dir, named "dir", of console);
+    make_builtin_fn!(dir, named "dirxml", of console);
     console.set_internal_state(ConsoleState::new());
     console
 }

--- a/boa/src/builtins/error.rs
+++ b/boa/src/builtins/error.rs
@@ -12,8 +12,7 @@
 
 use crate::{
     builtins::{
-        function::NativeFunctionData,
-        object::{ObjectKind, PROTOTYPE},
+        object::{internal_methods_trait::ObjectInternalMethods, Object, ObjectKind, PROTOTYPE},
         value::{to_value, ResultValue, Value, ValueData},
     },
     exec::Interpreter,
@@ -21,7 +20,7 @@ use crate::{
 use gc::Gc;
 
 /// Create a new error object.
-pub fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn make_error(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     if !args.is_empty() {
         this.set_field_slice(
             "message",
@@ -48,7 +47,7 @@ pub fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultVa
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
-pub fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn to_string(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     let name = this.get_field_slice("name");
     let message = this.get_field_slice("message");
     Ok(to_value(format!("{}: {}", name, message)))
@@ -60,9 +59,7 @@ pub fn _create(global: &Value) -> Value {
     prototype.set_field_slice("message", to_value(""));
     prototype.set_field_slice("name", to_value("Error"));
     make_builtin_fn!(to_string, named "toString", of prototype);
-    let error = to_value(make_error as NativeFunctionData);
-    error.set_field_slice(PROTOTYPE, prototype);
-    error
+    make_constructor_fn!(make_error, global, prototype)
 }
 
 /// Initialise the global object with the `Error` object.

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -1,134 +1,327 @@
-//! This module implements the global `Function` object.
+//! This module implements the global `Function` object as well as creates Native Functions.
 //!
-//! `Every JavaScript `function` is actually a `Function` object.
+//! Objects wrap `Function`s and expose them via call/construct slots.
+//!
+//! `The `Function` object is used for matching text with a pattern.
 //!
 //! More information:
 //!  - [ECMAScript reference][spec]
 //!  - [MDN documentation][mdn]
 //!
-//! [spec]: https://tc39.es/ecma262/#sec-function-object
+//! [spec]: https://tc39.es/ecma262/#sec-function-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
-
-#[cfg(test)]
-mod tests;
 
 use crate::{
     builtins::{
-        object::{internal_methods_trait::ObjectInternalMethods, Object},
+        array,
+        object::{Object, ObjectInternalMethods, ObjectKind, PROTOTYPE},
         property::Property,
         value::{to_value, ResultValue, Value, ValueData},
     },
-    exec::Interpreter,
+    environment::lexical_environment::{new_function_environment, Environment},
+    exec::Executor,
     syntax::ast::node::{FormalParameter, Node},
+    Interpreter,
 };
-use gc::{custom_trace, Gc};
+use gc::{unsafe_empty_trace, Gc, Trace};
 use gc_derive::{Finalize, Trace};
 use std::fmt::{self, Debug};
-use std::ops::Deref;
 
-/// fn(this, arguments, ctx)
-pub type NativeFunctionData = fn(&Value, &[Value], &mut Interpreter) -> ResultValue;
+/// _fn(this, arguments, ctx) -> ResultValue_ - The signature of a built-in function
+pub type NativeFunctionData = fn(&mut Value, &[Value], &mut Interpreter) -> ResultValue;
 
-/// A Javascript `Function` object instance.
-///
-/// A member of the Object type that may be invoked as a subroutine
-///
-/// In our implementation, Function is extending Object by holding an object field which some extra data
-#[derive(Trace, Finalize, Debug, Clone)]
-pub enum Function {
-    /// A native javascript function
-    NativeFunc(NativeFunction),
-    /// A regular javascript function
-    RegularFunc(RegularFunction),
+/// Sets the ConstructorKind
+#[derive(Debug, Copy, Clone)]
+pub enum ConstructorKind {
+    Base,
+    Derived,
 }
 
-/// Represents a regular javascript function in memory.
+/// Defines how this references are interpreted within the formal parameters and code body of the function.
+///
+/// Arrow functions don't define a `this` and thus are lexical, `function`s do define a this and thus are NonLexical
 #[derive(Trace, Finalize, Debug, Clone)]
-pub struct RegularFunction {
-    /// The fields associated with the function
-    pub object: Object,
-    /// This function's expression
-    pub node: Node,
-    /// The argument declarations of the function
-    pub args: Vec<Node>,
+pub enum ThisMode {
+    Lexical,
+    NonLexical,
 }
 
-impl RegularFunction {
-    /// Make a new regular function
-    #[allow(clippy::cast_possible_wrap)]
-    pub fn new(node: Node, f_args: Vec<FormalParameter>) -> Self {
-        let mut args = vec![];
-        for i in f_args {
-            let node = if let Some(init) = &i.init {
-                init.deref().clone()
-            } else {
-                Node::Local(i.name.clone())
-            };
-            args.push(node);
+/// FunctionBody is specific to this interpreter, it will either be Rust code or JavaScript code (AST Node)
+#[derive(Clone, Finalize)]
+pub enum FunctionBody {
+    BuiltIn(NativeFunctionData),
+    Ordinary(Node),
+}
+
+impl Debug for FunctionBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BuiltIn(_) => write!(f, "native code"),
+            Self::Ordinary(node) => write!(f, "{}", node),
         }
-
-        let mut object = Object::default();
-        object.properties.insert(
-            "arguments".to_string(),
-            Property::default().value(Gc::new(ValueData::Integer(args.len() as i32))),
-        );
-        Self { object, node, args }
     }
 }
 
-/// Represents a native javascript function in memory
-#[derive(Finalize, Clone)]
-pub struct NativeFunction {
-    /// The fields associated with the function
-    pub object: Object,
-    /// The callable function data
-    pub data: NativeFunctionData,
+/// `Trace` implementation for `FunctionBody`.
+///
+/// This is indeed safe, but we need to mark this as an empty trace because neither
+// `NativeFunctionData` nor Node hold any GC'd objects, but Gc doesn't know that. So we need to
+/// signal it manually. `rust-gc` does not have a `Trace` implementation for `fn(_, _, _)`.
+///
+/// <https://github.com/Manishearth/rust-gc/blob/master/gc/src/trace.rs>
+unsafe impl Trace for FunctionBody {
+    unsafe_empty_trace!();
 }
 
-impl NativeFunction {
-    /// Make a new native function with the given function data
-    pub fn new(data: NativeFunctionData) -> Self {
-        let object = Object::default();
-        Self { object, data }
+/// Signal what sort of function this is
+#[derive(Clone, Debug, Copy, Finalize)]
+pub enum FunctionKind {
+    BuiltIn,
+    Ordinary,
+}
+
+/// Waiting on <https://github.com/Manishearth/rust-gc/issues/87> until we can derive Copy
+unsafe impl Trace for FunctionKind {
+    unsafe_empty_trace!();
+}
+
+/// Boa representation of a Function Object.
+///
+/// <https://tc39.es/ecma262/#sec-ecmascript-function-objects>
+#[derive(Trace, Finalize, Clone)]
+pub struct Function {
+    /// Call/Construct Function body
+    pub body: FunctionBody,
+    /// Formal Paramaters
+    pub params: Vec<FormalParameter>,
+    /// This Mode
+    pub this_mode: ThisMode,
+    /// Function kind
+    pub kind: FunctionKind,
+    // Environment, built-in functions don't need Environments
+    pub environment: Option<Environment>,
+}
+
+impl Function {
+    /// This will create an ordinary function object
+    ///
+    /// <https://tc39.es/ecma262/#sec-ordinaryfunctioncreate>
+    pub fn create_ordinary(
+        parameter_list: Vec<FormalParameter>,
+        scope: Environment,
+        body: FunctionBody,
+        this_mode: ThisMode,
+    ) -> Self {
+        Self {
+            body,
+            environment: Some(scope),
+            params: parameter_list,
+            kind: FunctionKind::Ordinary,
+            this_mode,
+        }
+    }
+
+    /// This will create a built-in function object
+    ///
+    /// <https://tc39.es/ecma262/#sec-createbuiltinfunction>
+    pub fn create_builtin(parameter_list: Vec<FormalParameter>, body: FunctionBody) -> Self {
+        Self {
+            body,
+            params: parameter_list,
+            this_mode: ThisMode::NonLexical,
+            kind: FunctionKind::BuiltIn,
+            environment: None,
+        }
+    }
+
+    /// This will handle calls for both ordinary and built-in functions
+    ///
+    /// <https://tc39.es/ecma262/#sec-prepareforordinarycall>
+    /// <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
+    pub fn call(
+        &self,
+        this: &mut Value, // represents a pointer to this function object wrapped in a GC (not a `this` JS object)
+        args_list: &[Value],
+        interpreter: &mut Interpreter,
+        this_obj: &mut Value,
+    ) -> ResultValue {
+        match self.kind {
+            FunctionKind::BuiltIn => match &self.body {
+                FunctionBody::BuiltIn(func) => func(this_obj, args_list, interpreter),
+                FunctionBody::Ordinary(_) => {
+                    panic!("Builtin function should not have Ordinary Function body")
+                }
+            },
+            FunctionKind::Ordinary => {
+                // Create a new Function environment who's parent is set to the scope of the function declaration (self.environment)
+                // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
+                let local_env = new_function_environment(
+                    this.clone(),
+                    this_obj.clone(),
+                    Some(self.environment.as_ref().unwrap().clone()),
+                );
+
+                // Add argument bindings to the function environment
+                for i in 0..self.params.len() {
+                    let param = self.params.get(i).expect("Could not get param");
+                    // Rest Parameters
+                    if param.is_rest_param {
+                        self.add_rest_param(param, i, args_list, interpreter, &local_env);
+                        break;
+                    }
+
+                    let value = args_list.get(i).expect("Could not get value");
+                    self.add_arguments_to_environment(param, value.clone(), &local_env);
+                }
+
+                // Add arguments object
+                let arguments_obj = create_unmapped_arguments_object(args_list);
+                local_env
+                    .borrow_mut()
+                    .create_mutable_binding("arguments".to_string(), false);
+                local_env
+                    .borrow_mut()
+                    .initialize_binding("arguments", arguments_obj);
+
+                interpreter.realm.environment.push(local_env);
+
+                // Call body should be set before reaching here
+                let result = match &self.body {
+                    FunctionBody::Ordinary(ref body) => interpreter.run(body),
+                    _ => panic!("Ordinary function should not have BuiltIn Function body"),
+                };
+
+                // local_env gets dropped here, its no longer needed
+                interpreter.realm.environment.pop();
+                result
+            }
+        }
+    }
+
+    pub fn construct(
+        &self,
+        this: &mut Value, // represents a pointer to this function object wrapped in a GC (not a `this` JS object)
+        args_list: &[Value],
+        interpreter: &mut Interpreter,
+        this_obj: &mut Value,
+    ) -> ResultValue {
+        match self.kind {
+            FunctionKind::BuiltIn => match &self.body {
+                FunctionBody::BuiltIn(func) => func(this_obj, args_list, interpreter),
+                FunctionBody::Ordinary(_) => {
+                    panic!("Builtin function should not have Ordinary Function body")
+                }
+            },
+            FunctionKind::Ordinary => {
+                // Create a new Function environment who's parent is set to the scope of the function declaration (self.environment)
+                // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
+                let local_env = new_function_environment(
+                    this.clone(),
+                    this_obj.clone(),
+                    Some(self.environment.as_ref().unwrap().clone()),
+                );
+
+                // Add argument bindings to the function environment
+                for (i, param) in self.params.iter().enumerate() {
+                    // Rest Parameters
+                    if param.is_rest_param {
+                        self.add_rest_param(param, i, args_list, interpreter, &local_env);
+                        break;
+                    }
+
+                    let value = args_list.get(i).expect("Could not get value");
+                    self.add_arguments_to_environment(param, value.clone(), &local_env);
+                }
+
+                // Add arguments object
+                let arguments_obj = create_unmapped_arguments_object(args_list);
+                local_env
+                    .borrow_mut()
+                    .create_mutable_binding("arguments".to_string(), false);
+                local_env
+                    .borrow_mut()
+                    .initialize_binding("arguments", arguments_obj);
+
+                interpreter.realm.environment.push(local_env);
+
+                // Call body should be set before reaching here
+                let result = match &self.body {
+                    FunctionBody::Ordinary(ref body) => interpreter.run(body),
+                    _ => panic!("Ordinary function should not have BuiltIn Function body"),
+                };
+
+                // local_env gets dropped here, its no longer needed
+                interpreter.realm.environment.pop();
+                result
+            }
+        }
+    }
+
+    // Adds the final rest parameters to the Environment as an array
+    fn add_rest_param(
+        &self,
+        param: &FormalParameter,
+        index: usize,
+        args_list: &[Value],
+        interpreter: &mut Interpreter,
+        local_env: &Environment,
+    ) {
+        // Create array of values
+        let array = array::new_array(interpreter).unwrap();
+        array::add_to_array_object(&array, &args_list[index..]).unwrap();
+
+        // Create binding
+        local_env
+            .borrow_mut()
+            .create_mutable_binding(param.name.clone(), false);
+
+        // Set Binding to value
+        local_env
+            .borrow_mut()
+            .initialize_binding(&param.name, array);
+    }
+
+    // Adds an argument to the environment
+    fn add_arguments_to_environment(
+        &self,
+        param: &FormalParameter,
+        value: Value,
+        local_env: &Environment,
+    ) {
+        // Create binding
+        local_env
+            .borrow_mut()
+            .create_mutable_binding(param.name.clone(), false);
+
+        // Set Binding to value
+        local_env
+            .borrow_mut()
+            .initialize_binding(&param.name, value);
     }
 }
 
-impl Debug for NativeFunction {
+impl Debug for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
-        for (key, val) in self.object.properties.iter() {
-            write!(
-                f,
-                "{}: {}",
-                key,
-                val.value
-                    .as_ref()
-                    .unwrap_or(&Gc::new(ValueData::Undefined))
-                    .clone()
-            )?;
-        }
+        write!(f, "[Not implemented]")?;
         write!(f, "}}")
     }
 }
 
-unsafe impl gc::Trace for NativeFunction {
-    custom_trace!(this, mark(&this.object));
+/// Function Prototype.
+///
+/// <https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object>
+pub fn create_function_prototype() {
+    let mut function_prototype: Object = Object::default();
+    // Set Kind to function (for historical & compatibility reasons)
+    // <https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object>
+    function_prototype.kind = ObjectKind::Function;
 }
 
-/// Create a new `Function` object
-pub fn _create() -> Value {
-    let function: Object = Object::default();
-    to_value(function)
-}
-/// Initialise the global object with the `Function` object
-pub fn init(global: &Value) {
-    let global_ptr = global;
-    global_ptr.set_field_slice("Function", _create());
-}
-
-/// Arguments
-/// https://tc39.es/ecma262/#sec-createunmappedargumentsobject
-pub fn create_unmapped_arguments_object(arguments_list: Vec<Value>) -> Value {
+/// Arguments.
+///
+/// <https://tc39.es/ecma262/#sec-createunmappedargumentsobject>
+pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
     let len = arguments_list.len();
     let mut obj = Object::default();
     obj.set_internal_slot("ParameterMap", Gc::new(ValueData::Undefined));
@@ -152,4 +345,17 @@ pub fn create_unmapped_arguments_object(arguments_list: Vec<Value>) -> Value {
     }
 
     to_value(obj)
+}
+
+/// Create new function `[[Construct]]`
+///
+// This gets called when a new Function() is created.
+pub fn make_function(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    this.set_kind(ObjectKind::Function);
+    Ok(this.clone())
+}
+
+pub fn create_constructor(global: &Value) -> Value {
+    let proto = ValueData::new_obj(Some(global));
+    make_constructor_fn!(make_function, make_function, global, proto)
 }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -13,7 +13,6 @@
 //! [json]: https://www.json.org/json-en.html
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
 
-use crate::builtins::function::NativeFunctionData;
 use crate::builtins::value::{to_value, ResultValue, Value, ValueData};
 use crate::exec::Interpreter;
 use serde_json::{self, Value as JSONValue};
@@ -34,7 +33,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#sec-json.parse
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
 // TODO: implement optional revever argument.
-pub fn parse(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn parse(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     match serde_json::from_str::<JSONValue>(
         &args
             .get(0)
@@ -63,7 +62,7 @@ pub fn parse(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-json.stringify
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-pub fn stringify(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn stringify(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let obj = args.get(0).expect("cannot get argument for JSON.stringify");
     let json = obj.to_json().to_string();
     Ok(to_value(json))

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -12,10 +12,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 
 use crate::{
-    builtins::{
-        function::NativeFunctionData,
-        value::{from_value, to_value, ResultValue, Value, ValueData},
-    },
+    builtins::value::{from_value, to_value, ResultValue, Value, ValueData},
     exec::Interpreter,
 };
 use rand::random;
@@ -32,7 +29,7 @@ mod tests;
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.abs
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
-pub fn abs(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn abs(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -50,7 +47,7 @@ pub fn abs(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.acos
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
-pub fn acos(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn acos(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -68,7 +65,7 @@ pub fn acos(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
-pub fn acosh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn acosh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -86,7 +83,7 @@ pub fn acosh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.asin
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
-pub fn asin(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn asin(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -104,7 +101,7 @@ pub fn asin(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
-pub fn asinh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn asinh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -122,7 +119,7 @@ pub fn asinh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.atan
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan
-pub fn atan(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn atan(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -140,7 +137,7 @@ pub fn atan(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
-pub fn atanh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn atanh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -158,7 +155,7 @@ pub fn atanh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.atan2
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
-pub fn atan2(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn atan2(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -176,7 +173,7 @@ pub fn atan2(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.cbrt
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
-pub fn cbrt(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn cbrt(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -194,7 +191,7 @@ pub fn cbrt(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.ceil
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
-pub fn ceil(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn ceil(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -212,7 +209,7 @@ pub fn ceil(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.cos
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
-pub fn cos(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn cos(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -230,7 +227,7 @@ pub fn cos(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.cosh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
-pub fn cosh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn cosh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -248,7 +245,7 @@ pub fn cosh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.exp
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
-pub fn exp(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn exp(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -266,7 +263,7 @@ pub fn exp(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.floor
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
-pub fn floor(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn floor(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -284,7 +281,7 @@ pub fn floor(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.log
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
-pub fn log(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn log(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -307,7 +304,7 @@ pub fn log(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.log10
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10
-pub fn log10(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn log10(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -330,7 +327,7 @@ pub fn log10(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.log2
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
-pub fn log2(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn log2(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -353,7 +350,7 @@ pub fn log2(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.max
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max
-pub fn max(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn max(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let mut max = f64::NEG_INFINITY;
     for arg in args {
         let num = arg.to_num();
@@ -370,7 +367,7 @@ pub fn max(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.min
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min
-pub fn min(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn min(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     let mut max = f64::INFINITY;
     for arg in args {
         let num = arg.to_num();
@@ -387,7 +384,7 @@ pub fn min(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.pow
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
-pub fn pow(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn pow(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.len() >= 2 {
         let num: f64 = from_value(args.get(0).expect("Could not get argument").clone())
             .expect("Could not convert argument to f64");
@@ -407,7 +404,7 @@ pub fn pow(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.random
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-pub fn _random(_: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn _random(_: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(random::<f64>()))
 }
 
@@ -419,7 +416,7 @@ pub fn _random(_: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.round
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-pub fn round(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn round(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -437,7 +434,7 @@ pub fn round(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.sign
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
-pub fn sign(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn sign(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -460,7 +457,7 @@ pub fn sign(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.sin
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
-pub fn sin(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn sin(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -478,7 +475,7 @@ pub fn sin(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.sinh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh
-pub fn sinh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn sinh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -496,7 +493,7 @@ pub fn sinh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.sqrt
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt
-pub fn sqrt(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn sqrt(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -506,7 +503,7 @@ pub fn sqrt(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     }))
 }
 /// Get the tangent of a number
-pub fn tan(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn tan(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -524,7 +521,7 @@ pub fn tan(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.tanh
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh
-pub fn tanh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn tanh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {
@@ -542,7 +539,7 @@ pub fn tanh(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
-pub fn trunc(_: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn trunc(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     Ok(to_value(if args.is_empty() {
         f64::NAN
     } else {

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -5,13 +5,80 @@
 /// If no length is provided, the length will be set to 0.
 macro_rules! make_builtin_fn {
     ($fn:ident, named $name:expr, with length $l:tt, of $p:ident) => {
-        let $fn = to_value($fn as NativeFunctionData);
-        $fn.set_field_slice("length", to_value($l));
-        $p.set_field_slice($name, $fn);
+        let func = crate::builtins::function::Function::create_builtin(
+            vec![],
+            crate::builtins::function::FunctionBody::BuiltIn($fn),
+        );
+
+        let mut new_func = crate::builtins::object::Object::function();
+        new_func.set_call(func);
+        let new_func_obj = to_value(new_func);
+        new_func_obj.set_field_slice("length", to_value($l));
+        $p.set_field_slice($name, new_func_obj);
     };
     ($fn:ident, named $name:expr, of $p:ident) => {
         make_builtin_fn!($fn, named $name, with length 0, of $p);
     };
+}
+
+/// Macro to create a new constructor function
+///
+/// Either (construct_body, global, prototype)
+macro_rules! make_constructor_fn {
+    ($body:ident, $global:ident, $proto:ident) => {{
+        // Create the native function
+        let constructor_fn = crate::builtins::function::Function::create_builtin(
+            vec![],
+            crate::builtins::function::FunctionBody::BuiltIn($body),
+        );
+
+        // Get reference to Function.prototype
+        let func_prototype = $global
+            .get_field_slice("Function")
+            .get_field_slice(PROTOTYPE);
+
+        // Create the function object and point its instance prototype to Function.prototype
+        let mut constructor_obj = Object::function();
+        constructor_obj.set_construct(constructor_fn);
+
+        constructor_obj.set_internal_slot("__proto__", func_prototype);
+        let constructor_val = to_value(constructor_obj);
+
+        // Set proto.constructor -> constructor_obj
+        $proto.set_field_slice("constructor", constructor_val.clone());
+        constructor_val.set_field_slice(PROTOTYPE, $proto);
+
+        constructor_val
+    }};
+    ($construct_body:ident, $call_body:ident, $global:ident, $proto:ident) => {{
+        // Create the native functions
+        let construct_fn = crate::builtins::function::Function::create_builtin(
+            vec![],
+            crate::builtins::function::FunctionBody::BuiltIn($construct_body),
+        );
+        let call_fn = crate::builtins::function::Function::create_builtin(
+            vec![],
+            crate::builtins::function::FunctionBody::BuiltIn($call_body),
+        );
+
+        // Get reference to Function.prototype
+        let func_prototype = $global
+            .get_field_slice("Function")
+            .get_field_slice(PROTOTYPE);
+
+        // Create the function object and point its instance prototype to Function.prototype
+        let mut constructor_obj = Object::function();
+        constructor_obj.set_construct(construct_fn);
+        constructor_obj.set_call(call_fn);
+        constructor_obj.set_internal_slot("__proto__", func_prototype);
+        let constructor_val = to_value(constructor_obj);
+
+        // Set proto.constructor -> constructor_obj
+        $proto.set_field_slice("constructor", constructor_val.clone());
+        constructor_val.set_field_slice(PROTOTYPE, $proto);
+
+        constructor_val
+    }};
 }
 
 pub mod array;

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -18,8 +18,7 @@ mod tests;
 
 use crate::{
     builtins::{
-        function::NativeFunctionData,
-        object::{internal_methods_trait::ObjectInternalMethods, Object, ObjectKind, PROTOTYPE},
+        object::{internal_methods_trait::ObjectInternalMethods, Object, PROTOTYPE},
         value::{to_value, ResultValue, Value, ValueData},
     },
     exec::Interpreter,
@@ -36,7 +35,7 @@ fn to_number(value: &Value) -> Value {
                 to_value(0)
             }
         }
-        ValueData::Function(_) | ValueData::Symbol(_) | ValueData::Undefined => to_value(f64::NAN),
+        ValueData::Symbol(_) | ValueData::Undefined => to_value(f64::NAN),
         ValueData::Integer(i) => to_value(f64::from(i)),
         ValueData::Object(ref o) => (o).deref().borrow().get_internal_slot("NumberData"),
         ValueData::Null => to_value(0),
@@ -58,7 +57,7 @@ fn num_to_exponential(n: f64) -> String {
 }
 
 /// Create a new number `[[Construct]]`
-pub fn make_number(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn make_number(this: &mut Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let data = match args.get(0) {
         Some(ref value) => to_number(value),
         None => to_number(&to_value(0)),
@@ -70,7 +69,7 @@ pub fn make_number(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> Resu
 /// `Number()` function.
 ///
 /// More Information https://tc39.es/ecma262/#sec-number-constructor-number-value
-pub fn call_number(_this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn call_number(_this: &mut Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let data = match args.get(0) {
         Some(ref value) => to_number(value),
         None => to_number(&to_value(0)),
@@ -88,7 +87,7 @@ pub fn call_number(_this: &Value, args: &[Value], _ctx: &mut Interpreter) -> Res
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.toexponential
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential
-pub fn to_exponential(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn to_exponential(this: &mut Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let this_num = to_number(this).to_num();
     let this_str_num = num_to_exponential(this_num);
     Ok(to_value(this_str_num))
@@ -104,7 +103,7 @@ pub fn to_exponential(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> 
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tofixed
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed
-pub fn to_fixed(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn to_fixed(this: &mut Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let this_num = to_number(this).to_num();
     let precision = match args.get(0) {
         Some(n) => match n.to_int() {
@@ -130,7 +129,7 @@ pub fn to_fixed(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultV
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tolocalestring
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
-pub fn to_locale_string(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn to_locale_string(this: &mut Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let this_num = to_number(this).to_num();
     let this_str_num = format!("{}", this_num);
     Ok(to_value(this_str_num))
@@ -146,7 +145,7 @@ pub fn to_locale_string(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.toexponential
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
-pub fn to_precision(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn to_precision(this: &mut Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     let this_num = to_number(this);
     let _num_str_len = format!("{}", this_num.to_num()).len();
     let _precision = match args.get(0) {
@@ -170,7 +169,7 @@ pub fn to_precision(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> Res
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tostring
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString
-pub fn to_string(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn to_string(this: &mut Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     Ok(to_value(format!("{}", to_number(this).to_num())))
 }
 
@@ -184,20 +183,13 @@ pub fn to_string(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> Resul
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.valueof
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf
-pub fn value_of(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+pub fn value_of(this: &mut Value, _args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
     Ok(to_number(this))
 }
 
 /// Create a new `Number` object
 pub fn create_constructor(global: &Value) -> Value {
-    let mut number_constructor = Object::default();
-    number_constructor.kind = ObjectKind::Function;
-
-    number_constructor.set_internal_method("construct", make_number);
-    number_constructor.set_internal_method("call", call_number);
-
     let number_prototype = ValueData::new_obj(Some(global));
-
     number_prototype.set_internal_slot("NumberData", to_value(0));
 
     make_builtin_fn!(to_exponential, named "toExponential", with length 1, of number_prototype);
@@ -207,8 +199,5 @@ pub fn create_constructor(global: &Value) -> Value {
     make_builtin_fn!(to_string, named "toString", with length 1, of number_prototype);
     make_builtin_fn!(value_of, named "valueOf", of number_prototype);
 
-    let number = to_value(number_constructor);
-    number_prototype.set_field_slice("constructor", number.clone());
-    number.set_field_slice(PROTOTYPE, number_prototype);
-    number
+    make_constructor_fn!(make_number, call_number, global, number_prototype)
 }

--- a/boa/src/builtins/object/internal_methods_trait.rs
+++ b/boa/src/builtins/object/internal_methods_trait.rs
@@ -8,7 +8,7 @@
 use crate::builtins::{
     object::{Object, INSTANCE_PROTOTYPE},
     property::Property,
-    value::{to_value, Value, ValueData},
+    value::{same_value, to_value, Value, ValueData},
 };
 use gc::Gc;
 use std::borrow::Borrow;
@@ -39,7 +39,7 @@ pub trait ObjectInternalMethods {
                 // the parent value variant should be an object
                 // In the unlikely event it isn't return false
                 return match *parent {
-                    ValueData::Object(ref obj) => obj.borrow().has_property(val),
+                    ValueData::Object(ref obj) => (*obj).deref().borrow().has_property(val),
                     _ => false,
                 };
             }
@@ -168,6 +168,116 @@ pub trait ObjectInternalMethods {
         }
     }
 
+    fn define_own_property(&mut self, property_key: String, desc: Property) -> bool {
+        let mut current = self.get_own_property(&to_value(property_key.to_string()));
+        let extensible = self.is_extensible();
+
+        // https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
+        // There currently isn't a property, lets create a new one
+        if current.value.is_none() || current.value.as_ref().expect("failed").is_undefined() {
+            if !extensible {
+                return false;
+            }
+
+            self.insert_property(property_key, desc);
+            return true;
+        }
+        // If every field is absent we don't need to set anything
+        if desc.is_none() {
+            return true;
+        }
+
+        // 4
+        if !current.configurable.unwrap_or(false) {
+            if desc.configurable.is_some() && desc.configurable.expect("unable to get prop desc") {
+                return false;
+            }
+
+            if desc.enumerable.is_some()
+                && (desc.enumerable.as_ref().expect("unable to get prop desc")
+                    != current
+                        .enumerable
+                        .as_ref()
+                        .expect("unable to get prop desc"))
+            {
+                return false;
+            }
+        }
+
+        // 5
+        if desc.is_generic_descriptor() {
+            // 6
+        } else if current.is_data_descriptor() != desc.is_data_descriptor() {
+            // a
+            if !current.configurable.expect("unable to get prop desc") {
+                return false;
+            }
+            // b
+            if current.is_data_descriptor() {
+                // Convert to accessor
+                current.value = None;
+                current.writable = None;
+            } else {
+                // c
+                // convert to data
+                current.get = None;
+                current.set = None;
+            }
+
+            self.insert_property(property_key.clone(), current);
+        // 7
+        } else if current.is_data_descriptor() && desc.is_data_descriptor() {
+            // a
+            if !current.configurable.expect("unable to get prop desc")
+                && !current.writable.expect("unable to get prop desc")
+            {
+                if desc.writable.is_some() && desc.writable.expect("unable to get prop desc") {
+                    return false;
+                }
+
+                if desc.value.is_some()
+                    && !same_value(
+                        &desc.value.clone().unwrap(),
+                        &current.value.clone().unwrap(),
+                        false,
+                    )
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        // 8
+        } else {
+            if !current.configurable.unwrap() {
+                if desc.set.is_some()
+                    && !same_value(
+                        &desc.set.clone().unwrap(),
+                        &current.set.clone().unwrap(),
+                        false,
+                    )
+                {
+                    return false;
+                }
+
+                if desc.get.is_some()
+                    && !same_value(
+                        &desc.get.clone().unwrap(),
+                        &current.get.clone().unwrap(),
+                        false,
+                    )
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        // 9
+        self.insert_property(property_key, desc);
+        true
+    }
+
     /// https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
     /// The specification returns a Property Descriptor or Undefined. These are 2 separate types and we can't do that here.
     fn get_own_property(&self, prop: &Value) -> Property;
@@ -180,8 +290,6 @@ pub trait ObjectInternalMethods {
     fn get_prototype_of(&self) -> Value {
         self.get_internal_slot(INSTANCE_PROTOTYPE)
     }
-
-    fn define_own_property(&mut self, property_key: String, desc: Property) -> bool;
 
     /// Utility function to get an immutable internal slot or Null
     fn get_internal_slot(&self, name: &str) -> Value;

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -10,7 +10,7 @@ fn check_string_constructor_is_function() {
     assert_eq!(string_constructor.is_function(), true);
 }
 
-#[test]
+// #[test]
 // TODO: re-enable when getProperty() is finished;
 // fn length() {
 //     //TEST262: https://github.com/tc39/test262/blob/master/test/built-ins/String/length.js
@@ -35,6 +35,7 @@ fn check_string_constructor_is_function() {
 //     let d = forward(&mut engine, "d.length");
 //     assert_eq!(d, String::from("4"));
 // }
+
 #[test]
 fn concat() {
     let realm = Realm::create();

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -41,7 +41,7 @@ use rand::random;
 /// - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-symbol-description
-pub fn call_symbol(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+pub fn call_symbol(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
     // From an implementation and specificaition perspective Symbols are similar to Objects.
     // They have internal slots to hold the SymbolData and Description, they also have methods and a prototype.
     // So we start by creating an Object
@@ -66,7 +66,9 @@ pub fn call_symbol(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultVa
         .get_field_slice(PROTOTYPE);
     sym_instance.set_internal_slot(INSTANCE_PROTOTYPE, proto);
 
-    Ok(Gc::new(ValueData::Symbol(GcCell::new(sym_instance))))
+    Ok(Gc::new(ValueData::Symbol(Box::new(GcCell::new(
+        sym_instance,
+    )))))
 }
 
 /// `Symbol.prototype.toString()`
@@ -79,7 +81,7 @@ pub fn call_symbol(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultVa
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.tostring
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString
-pub fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+pub fn to_string(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
     let s: Value = this.get_internal_slot("Description");
     let full_string = format!(r#"Symbol({})"#, s.to_string());
     Ok(to_value(full_string))
@@ -96,24 +98,8 @@ pub fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue 
 /// [spec]: https://tc39.es/ecma262/#sec-symbol-constructor
 /// [mdn]:
 pub fn create_constructor(global: &Value) -> Value {
-    // Create Symbol constructor (or function in Symbol's case)
-    let mut symbol_constructor = Object::default();
-    symbol_constructor.set_internal_method("call", call_symbol);
-
-    // Create prototype
-    let mut symbol_prototype = Object::default();
-
-    // Symbol.prototype[[Prototype]] points to Object.prototype
-    // Symbol Constructor -> Symbol Prototype -> Object Prototype
-    let object_prototype = global.get_field_slice("Object").get_field_slice(PROTOTYPE);
-    symbol_prototype.set_internal_slot(INSTANCE_PROTOTYPE, object_prototype);
-    symbol_prototype.set_method("toString", to_string);
-
-    let symbol_prototype_val = to_value(symbol_prototype);
-
-    let symbol_constructor_value = to_value(symbol_constructor);
-    symbol_prototype_val.set_field_slice("construcotor", symbol_constructor_value.clone());
-    symbol_constructor_value.set_field_slice(PROTOTYPE, symbol_prototype_val);
-
-    symbol_constructor_value
+    // Create prototype object
+    let proto = ValueData::new_obj(Some(global));
+    make_builtin_fn!(to_string, named "toString", of proto);
+    make_constructor_fn!(call_symbol, call_symbol, global, proto)
 }

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -41,7 +41,7 @@ pub struct FunctionEnvironmentRecord {
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.
     pub this_binding_status: BindingStatus,
     /// The function object whose invocation caused this Environment Record to be created.
-    pub function_object: Value,
+    pub function: Value,
     /// If the associated function has super property accesses and is not an ArrowFunction,
     /// [[HomeObject]] is the object that the function is bound to as a method.
     /// The default value for [[HomeObject]] is undefined.

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -229,11 +229,10 @@ pub fn new_function_environment(
     new_target: Value,
     outer: Option<Environment>,
 ) -> Environment {
-    debug_assert!(f.is_function());
     debug_assert!(new_target.is_object() || new_target.is_undefined());
     Gc::new(GcCell::new(Box::new(FunctionEnvironmentRecord {
         env_rec: HashMap::new(),
-        function_object: f,
+        function: f,
         this_binding_status: BindingStatus::Uninitialized, // hardcoding to unitialized for now until short functions are properly supported
         home_object: Gc::new(ValueData::Undefined),
         new_target,

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -21,7 +21,7 @@
     rust_2018_compatibility,
     rust_2018_idioms,
     future_incompatible,
-    nonstandard_style
+    nonstandard_style,
 )]
 #![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
 #![allow(

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -20,7 +20,8 @@ use crate::{
 use gc::{Gc, GcCell};
 use std::collections::{hash_map::HashMap, hash_set::HashSet};
 
-/// Representation of a Realm.   
+/// Representation of a Realm.
+///
 /// In the specification these are called Realm Records.
 #[derive(Debug)]
 pub struct Realm {
@@ -54,14 +55,13 @@ impl Realm {
     fn create_instrinsics(&self) {
         let global = &self.global_obj;
         // Create intrinsics, add global objects here
-        function::init(global);
-
         global.set_field_slice("Array", array::create_constructor(global));
         global.set_field_slice("Boolean", boolean::create_constructor(global));
         global.set_field_slice("JSON", json::create_constructor(global));
         global.set_field_slice("Math", math::create_constructor(global));
         global.set_field_slice("Number", number::create_constructor(global));
         global.set_field_slice("Object", object::create_constructor(global));
+        global.set_field_slice("Function", function::create_constructor(global));
         global.set_field_slice("RegExp", regexp::create_constructor(global));
         global.set_field_slice("String", string::create_constructor(global));
         global.set_field_slice("Symbol", symbol::create_constructor(global));
@@ -70,8 +70,12 @@ impl Realm {
 
     /// Utility to add a function to the global object
     pub fn register_global_func(self, func_name: &str, func: NativeFunctionData) -> Self {
+        let func = crate::builtins::function::Function::create_builtin(
+            vec![],
+            crate::builtins::function::FunctionBody::BuiltIn(func),
+        );
         self.global_obj
-            .set_field(func_name.to_value(), func.to_value());
+            .set_field(func_name.to_value(), ValueData::from_func(func));
 
         self
     }

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -103,19 +103,19 @@ pub enum Const {
 
 impl From<&str> for Const {
     fn from(s: &str) -> Self {
-        Const::String(s.into())
+        Self::String(s.into())
     }
 }
 
 impl From<&String> for Const {
     fn from(s: &String) -> Self {
-        Const::String(s.clone())
+        Self::String(s.clone())
     }
 }
 
 impl From<String> for Const {
     fn from(s: String) -> Self {
-        Const::String(s)
+        Self::String(s)
     }
 }
 

--- a/boa/src/syntax/ast/node.rs
+++ b/boa/src/syntax/ast/node.rs
@@ -532,7 +532,7 @@ impl Node {
     /// Creates an `ArrayDecl` AST node.
     pub fn array_decl<N>(nodes: N) -> Self
     where
-        N: Into<Vec<Node>>,
+        N: Into<Vec<Self>>,
     {
         Self::ArrayDecl(nodes.into())
     }
@@ -541,7 +541,7 @@ impl Node {
     pub fn arrow_function_decl<P, B>(params: P, body: B) -> Self
     where
         P: Into<Vec<FormalParameter>>,
-        B: Into<Box<Node>>,
+        B: Into<Box<Self>>,
     {
         Self::ArrowFunctionDecl(params.into(), body.into())
     }
@@ -549,8 +549,8 @@ impl Node {
     /// Creates an `Assign` AST node.
     pub fn assign<L, R>(lhs: L, rhs: R) -> Self
     where
-        L: Into<Box<Node>>,
-        R: Into<Box<Node>>,
+        L: Into<Box<Self>>,
+        R: Into<Box<Self>>,
     {
         Self::Assign(lhs.into(), rhs.into())
     }
@@ -559,8 +559,8 @@ impl Node {
     pub fn bin_op<O, L, R>(op: O, lhs: L, rhs: R) -> Self
     where
         O: Into<BinOp>,
-        L: Into<Box<Node>>,
-        R: Into<Box<Node>>,
+        L: Into<Box<Self>>,
+        R: Into<Box<Self>>,
     {
         Self::BinOp(op.into(), lhs.into(), rhs.into())
     }
@@ -568,7 +568,7 @@ impl Node {
     /// Creates a `Block` AST node.
     pub fn block<N>(nodes: N) -> Self
     where
-        N: Into<Vec<Node>>,
+        N: Into<Vec<Self>>,
     {
         Self::Block(nodes.into())
     }
@@ -585,8 +585,8 @@ impl Node {
     /// Creates a `Call` AST node.
     pub fn call<F, P>(function: F, params: P) -> Self
     where
-        F: Into<Box<Node>>,
-        P: Into<Vec<Node>>,
+        F: Into<Box<Self>>,
+        P: Into<Vec<Self>>,
     {
         Self::Call(function.into(), params.into())
     }
@@ -594,9 +594,9 @@ impl Node {
     /// Creates a `ConditionalOp` AST node.
     pub fn conditional_op<C, T, F>(condition: C, if_true: T, if_false: F) -> Self
     where
-        C: Into<Box<Node>>,
-        T: Into<Box<Node>>,
-        F: Into<Box<Node>>,
+        C: Into<Box<Self>>,
+        T: Into<Box<Self>>,
+        F: Into<Box<Self>>,
     {
         Self::ConditionalOp(condition.into(), if_true.into(), if_false.into())
     }
@@ -612,7 +612,7 @@ impl Node {
     /// Creates a `ConstDecl` AST node.
     pub fn const_decl<D>(decl: D) -> Self
     where
-        D: Into<Vec<(String, Node)>>,
+        D: Into<Vec<(String, Self)>>,
     {
         Self::ConstDecl(decl.into())
     }
@@ -629,8 +629,8 @@ impl Node {
     /// Creates a `DoWhileLoop` AST node.
     pub fn do_while_loop<B, C>(body: B, condition: C) -> Self
     where
-        B: Into<Box<Node>>,
-        C: Into<Box<Node>>,
+        B: Into<Box<Self>>,
+        C: Into<Box<Self>>,
     {
         Self::DoWhileLoop(body.into(), condition.into())
     }
@@ -641,7 +641,7 @@ impl Node {
         N: Into<String>,
         ON: Into<Option<N>>,
         P: Into<Vec<FormalParameter>>,
-        B: Into<Box<Node>>,
+        B: Into<Box<Self>>,
     {
         Self::FunctionDecl(name.into().map(N::into), params.into(), body.into())
     }
@@ -649,7 +649,7 @@ impl Node {
     /// Creates a `GetConstField` AST node.
     pub fn get_const_field<V, L>(value: V, label: L) -> Self
     where
-        V: Into<Box<Node>>,
+        V: Into<Box<Self>>,
         L: Into<String>,
     {
         Self::GetConstField(value.into(), label.into())
@@ -658,8 +658,8 @@ impl Node {
     /// Creates a `GetField` AST node.
     pub fn get_field<V, F>(value: V, field: F) -> Self
     where
-        V: Into<Box<Node>>,
-        F: Into<Box<Node>>,
+        V: Into<Box<Self>>,
+        F: Into<Box<Self>>,
     {
         Self::GetField(value.into(), field.into())
     }
@@ -670,10 +670,10 @@ impl Node {
         OI: Into<Option<I>>,
         OC: Into<Option<C>>,
         OS: Into<Option<S>>,
-        I: Into<Box<Node>>,
-        C: Into<Box<Node>>,
-        S: Into<Box<Node>>,
-        B: Into<Box<Node>>,
+        I: Into<Box<Self>>,
+        C: Into<Box<Self>>,
+        S: Into<Box<Self>>,
+        B: Into<Box<Self>>,
     {
         Self::ForLoop(
             init.into().map(I::into),
@@ -686,9 +686,9 @@ impl Node {
     /// Creates an `If` AST node.
     pub fn if_node<C, B, E, OE>(condition: C, body: B, else_node: OE) -> Self
     where
-        C: Into<Box<Node>>,
-        B: Into<Box<Node>>,
-        E: Into<Box<Node>>,
+        C: Into<Box<Self>>,
+        B: Into<Box<Self>>,
+        E: Into<Box<Self>>,
         OE: Into<Option<E>>,
     {
         Self::If(condition.into(), body.into(), else_node.into().map(E::into))
@@ -697,7 +697,7 @@ impl Node {
     /// Creates a `LetDecl` AST node.
     pub fn let_decl<I>(init: I) -> Self
     where
-        I: Into<Vec<(String, Option<Node>)>>,
+        I: Into<Vec<(String, Option<Self>)>>,
     {
         Self::LetDecl(init.into())
     }
@@ -713,7 +713,7 @@ impl Node {
     /// Creates a `New` AST node.
     pub fn new<N>(node: N) -> Self
     where
-        N: Into<Box<Node>>,
+        N: Into<Box<Self>>,
     {
         Self::New(node.into())
     }
@@ -729,7 +729,7 @@ impl Node {
     /// Creates a `Return` AST node.
     pub fn return_node<E, OE>(expr: OE) -> Self
     where
-        E: Into<Box<Node>>,
+        E: Into<Box<Self>>,
         OE: Into<Option<E>>,
     {
         Self::Return(expr.into().map(E::into))
@@ -738,10 +738,10 @@ impl Node {
     /// Creates a `Switch` AST node.
     pub fn switch<V, C, OD, D>(val: V, cases: C, default: OD) -> Self
     where
-        V: Into<Box<Node>>,
-        C: Into<Vec<(Node, Vec<Node>)>>,
+        V: Into<Box<Self>>,
+        C: Into<Vec<(Self, Vec<Self>)>>,
         OD: Into<Option<D>>,
-        D: Into<Box<Node>>,
+        D: Into<Box<Self>>,
     {
         Self::Switch(val.into(), cases.into(), default.into().map(D::into))
     }
@@ -749,7 +749,7 @@ impl Node {
     /// Creates a `Spread` AST node.
     pub fn spread<V>(val: V) -> Self
     where
-        V: Into<Box<Node>>,
+        V: Into<Box<Self>>,
     {
         Self::Spread(val.into())
     }
@@ -757,7 +757,7 @@ impl Node {
     /// Creates a `StatementList` AST node.
     pub fn statement_list<L>(list: L) -> Self
     where
-        L: Into<Vec<Node>>,
+        L: Into<Vec<Self>>,
     {
         Self::StatementList(list.into())
     }
@@ -765,7 +765,7 @@ impl Node {
     /// Creates a `Throw` AST node.
     pub fn throw<V>(val: V) -> Self
     where
-        V: Into<Box<Node>>,
+        V: Into<Box<Self>>,
     {
         Self::Throw(val.into())
     }
@@ -773,7 +773,7 @@ impl Node {
     /// Creates a `TypeOf` AST node.
     pub fn type_of<E>(expr: E) -> Self
     where
-        E: Into<Box<Node>>,
+        E: Into<Box<Self>>,
     {
         Self::TypeOf(expr.into())
     }
@@ -781,13 +781,13 @@ impl Node {
     /// Creates a `Try` AST node.
     pub fn try_node<T, OC, OP, OF, C, P, F>(try_node: T, catch: OC, param: OP, finally: OF) -> Self
     where
-        T: Into<Box<Node>>,
+        T: Into<Box<Self>>,
         OC: Into<Option<C>>,
         OP: Into<Option<P>>,
         OF: Into<Option<F>>,
-        C: Into<Box<Node>>,
-        P: Into<Box<Node>>,
-        F: Into<Box<Node>>,
+        C: Into<Box<Self>>,
+        P: Into<Box<Self>>,
+        F: Into<Box<Self>>,
     {
         let catch = catch.into().map(C::into);
         let finally = finally.into().map(F::into);
@@ -808,7 +808,7 @@ impl Node {
     /// Creates a `UnaryOp` AST node.
     pub fn unary_op<V>(op: UnaryOp, val: V) -> Self
     where
-        V: Into<Box<Node>>,
+        V: Into<Box<Self>>,
     {
         Self::UnaryOp(op, val.into())
     }
@@ -816,7 +816,7 @@ impl Node {
     /// Creates a `VarDecl` AST node.
     pub fn var_decl<I>(init: I) -> Self
     where
-        I: Into<Vec<(String, Option<Node>)>>,
+        I: Into<Vec<(String, Option<Self>)>>,
     {
         Self::VarDecl(init.into())
     }
@@ -824,8 +824,8 @@ impl Node {
     /// Creates a `WhileLoop` AST node.
     pub fn while_loop<C, B>(condition: C, body: B) -> Self
     where
-        C: Into<Box<Node>>,
-        B: Into<Box<Node>>,
+        C: Into<Box<Self>>,
+        B: Into<Box<Self>>,
     {
         Self::WhileLoop(condition.into(), body.into())
     }

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -420,7 +420,10 @@ fn hexadecimal_edge_case() {
         TokenKind::Identifier(String::from("ff"))
     );
 
-    assert_eq!(lexer.tokens[3].kind, TokenKind::numeric_literal(0xffffff));
+    assert_eq!(
+        lexer.tokens[3].kind,
+        TokenKind::numeric_literal(0x00ff_ffff)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #141 

- [x] Implement fmt::Display for new function
- [x] Fix isFunction()
- [x] Better documentation for functions
- [x] Fall back to construct if call is not defined
- [x] all functions point to Function.prototype internally
- [x] leaner make_constructer_fn!()
- [x] deprecation of set_internal_method()
- [x] deprecation of set_method()
- [x] construct / call duplication
- [x] typeof is both a Node and a method in Value