### PR TITLE
Fixed comments lexing

### DIFF
--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -51,8 +51,13 @@ pub fn forward(engine: &mut Interpreter, src: &str) -> String {
 /// If the interpreter fails parsing an error value is returned instead (error object)
 pub fn forward_val(engine: &mut Interpreter, src: &str) -> ResultValue {
     // Setup executor
-    let expr = parser_expr(src).unwrap();
-    engine.run(&expr)
+    match parser_expr(src) {
+        Ok(expr) => engine.run(&expr),
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Create a clean Interpreter and execute the code

--- a/boa/src/syntax/parser.rs
+++ b/boa/src/syntax/parser.rs
@@ -25,13 +25,15 @@ impl fmt::Display for ParseError {
         match self {
             ParseError::Expected(expected, actual, routine) => write!(
                 f,
-                "Expected token '{}', got '{}' in routine '{}'",
+                "Expected token '{}', got '{}' in routine '{}' at line {}, col {}",
                 expected
                     .first()
                     .map(|t| t.to_string())
                     .unwrap_or_else(String::new),
                 actual,
-                routine
+                routine,
+                actual.pos.line_number,
+                actual.pos.column_number
             ),
             ParseError::ExpectedExpr(expected, actual) => {
                 write!(f, "Expected expression '{}', got '{}'", expected, actual)

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 struct Opt {
     /// The javascript file to be evaluated.
     #[structopt(name = "FILE", parse(from_os_str), default_value = "tests/js/test.js")]
-    file: PathBuf,
+    files: Vec<PathBuf>,
     /// Open a boa shell (WIP).
     #[structopt(short, long)]
     shell: bool,
@@ -21,14 +21,16 @@ struct Opt {
 pub fn main() -> Result<(), std::io::Error> {
     let args = Opt::from_args();
 
-    let buffer = read_to_string(args.file)?;
-
     let realm = Realm::create();
     let mut engine = Executor::new(realm);
 
-    match forward_val(&mut engine, &buffer) {
-        Ok(v) => print!("{}", v.to_string()),
-        Err(v) => eprint!("{}", v.to_string()),
+    for file in args.files {
+        let buffer = read_to_string(file)?;
+
+        match forward_val(&mut engine, &buffer) {
+            Ok(v) => print!("{}", v.to_string()),
+            Err(v) => eprint!("{}", v.to_string()),
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This fixes a bug in comment lexing, where the initial `/` was not being included in the comment token, and the line number and column numbers were wrong. This would break the numbering of a whole file if there was a multiline comment.

Also, I have added the line and column numbers to the parsing errors, and properly printed them in case of failure, instead of panicking with a debug message.

This should make debugging much easier.