### PR TITLE
Fixed empty returns

### DIFF
--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -222,7 +222,13 @@ impl Parser {
 
                 Ok(Expr::new(ExprDef::ConstDecl(vars)))
             }
-            Keyword::Return => Ok(Expr::new(ExprDef::Return(Some(Box::new(self.parse()?))))),
+            Keyword::Return => match self.get_token(self.pos)?.data {
+                TokenData::Punctuator(Punctuator::Semicolon)
+                | TokenData::Punctuator(Punctuator::CloseBlock) => {
+                    Ok(Expr::new(ExprDef::Return(None)))
+                }
+                _ => Ok(Expr::new(ExprDef::Return(Some(Box::new(self.parse()?))))),
+            },
             Keyword::New => {
                 let call = self.parse()?;
                 match call.def {

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -632,6 +632,28 @@ fn check_function_declarations() {
     );
 
     check_parser(
+        "function foo(a) { return; }",
+        &[Expr::new(ExprDef::FunctionDecl(
+            Some(String::from("foo")),
+            vec![Expr::new(ExprDef::Local(String::from("a")))],
+            Box::new(Expr::new(ExprDef::Block(vec![Expr::new(ExprDef::Return(
+                None,
+            ))]))),
+        ))],
+    );
+
+    check_parser(
+        "function foo(a) { return }",
+        &[Expr::new(ExprDef::FunctionDecl(
+            Some(String::from("foo")),
+            vec![Expr::new(ExprDef::Local(String::from("a")))],
+            Box::new(Expr::new(ExprDef::Block(vec![Expr::new(ExprDef::Return(
+                None,
+            ))]))),
+        ))],
+    );
+
+    check_parser(
         "function (a, ...b) {}",
         &[Expr::new(ExprDef::FunctionDecl(
             None,
@@ -685,6 +707,32 @@ fn check_function_declarations() {
                     Expr::new(ExprDef::Local(String::from("a"))),
                     Expr::new(ExprDef::Local(String::from("b"))),
                 ))),
+            ))]))),
+        ))],
+    );
+
+    check_parser(
+        "(a, b) => { return; }",
+        &[Expr::new(ExprDef::ArrowFunctionDecl(
+            vec![
+                Expr::new(ExprDef::Local(String::from("a"))),
+                Expr::new(ExprDef::Local(String::from("b"))),
+            ],
+            Box::new(Expr::new(ExprDef::Block(vec![Expr::new(ExprDef::Return(
+                None,
+            ))]))),
+        ))],
+    );
+
+    check_parser(
+        "(a, b) => { return }",
+        &[Expr::new(ExprDef::ArrowFunctionDecl(
+            vec![
+                Expr::new(ExprDef::Local(String::from("a"))),
+                Expr::new(ExprDef::Local(String::from("b"))),
+            ],
+            Box::new(Expr::new(ExprDef::Block(vec![Expr::new(ExprDef::Return(
+                None,
             ))]))),
         ))],
     );


### PR DESCRIPTION
This fixes #251, the parsing of empty returns. I added some tests to make sure it doesn't break again.