### PR TITLE
Improved parser error messages

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -55,8 +55,8 @@ impl RegularFunction {
     }
 }
 
-#[derive(Finalize, Clone)]
 /// Represents a native javascript function in memory
+#[derive(Finalize, Clone)]
 pub struct NativeFunction {
     /// The fields associated with the function
     pub object: Object,

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -21,9 +21,10 @@ use std::{
     str::FromStr,
 };
 
-#[must_use]
 /// The result of a Javascript expression is represented like this so it can succeed (`Ok`) or fail (`Err`)
+#[must_use]
 pub type ResultValue = Result<Value, Value>;
+
 /// A Garbage-collected Javascript value as represented in the interpreter
 pub type Value = Gc<ValueData>;
 

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -1,8 +1,8 @@
 use gc_derive::{Finalize, Trace};
 use std::fmt::{Display, Formatter, Result};
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A Javascript Constant
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum Const {
     /// A UTF-8 string, such as `"Hello, world"`
     String(String),

--- a/boa/src/syntax/ast/expr.rs
+++ b/boa/src/syntax/ast/expr.rs
@@ -27,8 +27,8 @@ impl Display for Expr {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A Javascript Expression
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum ExprDef {
     /// Run a operation between 2 expressions
     BinOp(BinOp, Box<Expr>, Box<Expr>),

--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -4,9 +4,9 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Clone, Copy, PartialEq, Debug)]
 /// A Javascript Keyword
 /// As specificed by <https://www.ecma-international.org/ecma-262/#sec-keywords>
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Keyword {
     /// The `await` keyword
     Await,

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -13,8 +13,8 @@ pub trait Operator {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A numeric operation between 2 values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum NumOp {
     /// `a + b` - Addition
     Add,
@@ -47,8 +47,8 @@ impl Display for NumOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A unary operation on a single value
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum UnaryOp {
     /// `a++` - increment the value
     IncrementPost,
@@ -88,8 +88,8 @@ impl Display for UnaryOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A bitwise operation between 2 values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum BitOp {
     /// `a & b` - Bitwise and
     And,
@@ -119,8 +119,8 @@ impl Display for BitOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A comparitive operation between 2 values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum CompOp {
     /// `a == b` - Equality
     Equal,
@@ -159,8 +159,8 @@ impl Display for CompOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A logical operation between 2 boolean values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum LogOp {
     /// `a && b` - Logical and
     And,
@@ -181,8 +181,8 @@ impl Display for LogOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A binary operation between 2 values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum BinOp {
     /// Numeric operation
     Num(NumOp),
@@ -240,8 +240,8 @@ impl Display for BinOp {
     }
 }
 
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A binary operation between 2 values
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum AssignOp {
     /// `a += b` - Add assign
     Add,

--- a/boa/src/syntax/ast/pos.rs
+++ b/boa/src/syntax/ast/pos.rs
@@ -1,9 +1,9 @@
-#[derive(Clone, Copy, PartialEq, Debug)]
 /// A position in the Javascript source code
 /// Stores both the column number and the line number
 ///
 /// ## Similar Implementations
 /// [V8: Location](https://cs.chromium.org/chromium/src/v8/src/parsing/scanner.h?type=cs&q=isValid+Location&g=0&l=216)
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Position {
     // Column number
     pub column_number: u64,

--- a/boa/src/syntax/ast/punc.rs
+++ b/boa/src/syntax/ast/punc.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Error, Formatter};
 
-#[derive(PartialEq, Clone, Copy, Debug)]
 /// Punctuation
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum Punctuator {
     /// `+`
     Add,

--- a/boa/src/syntax/ast/token.rs
+++ b/boa/src/syntax/ast/token.rs
@@ -1,9 +1,8 @@
 use crate::syntax::ast::{keyword::Keyword, pos::Position, punc::Punctuator};
 use std::fmt::{Debug, Display, Formatter, Result};
 
-#[derive(Clone, PartialEq)]
 /// Represents a token
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     /// The token Data
     pub data: TokenData,
@@ -39,8 +38,8 @@ impl Debug for VecToken {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
 /// Represents the type of Token
+#[derive(Clone, PartialEq, Debug)]
 pub enum TokenData {
     /// A boolean literal, which is either `true` or `false`
     BooleanLiteral(bool),


### PR DESCRIPTION
Parser error messages now also include the line and the column where the offending lexer tokens started. This should make it easier to debug JavaScript code, and also the limitations of the engine itself.

I also took the opportunity to idiomatize some derives. Since derives
are part of the definition of a structure/type, they should go with
the definition, and not with the comments.