### PR TITLE
Added indentation and better Display implementation for AST nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -32,12 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,12 +41,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -76,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -88,24 +76,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
+checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-
-[[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cast"
@@ -174,24 +153,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -208,11 +189,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -232,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
@@ -284,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
@@ -308,9 +289,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -323,9 +304,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "log"
@@ -337,31 +318,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.3.0"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
-dependencies = [
- "libc",
-]
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check",
+ "autocfg",
 ]
 
 [[package]]
@@ -370,7 +344,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -409,35 +383,35 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.2",
- "rustversion",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "version_check",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5717d9fa2664351a01ed73ba5ef6df09c01a521cb42cb65a061432a826f3c7a"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
  "proc-macro2",
- "quote 1.0.2",
- "rustversion",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "syn-mid",
+ "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -450,9 +424,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
@@ -472,11 +446,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -524,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -536,18 +510,18 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "rustc_version"
@@ -559,21 +533,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
-]
-
-[[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "same-file"
@@ -586,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -607,37 +570,31 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953"
+checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sourcefile"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "strsim"
@@ -647,9 +604,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bcbed7d48956fcbb5d80c6b95aedb553513de0a1b451ea92679d999c010e98"
+checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
 dependencies = [
  "clap",
  "lazy_static",
@@ -658,15 +615,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
+checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -682,12 +639,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
  "proc-macro2",
- "quote 1.0.2",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -698,8 +655,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -781,9 +738,9 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "walkdir"
@@ -804,9 +761,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -814,84 +771,56 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.17",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
-
-[[package]]
-name = "wasm-bindgen-webidl"
-version = "0.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
-dependencies = [
- "anyhow",
- "heck",
- "log",
- "proc-macro2",
- "quote 1.0.2",
- "syn 1.0.14",
- "wasm-bindgen-backend",
- "weedle",
-]
+checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
 
 [[package]]
 name = "web-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
 dependencies = [
- "anyhow",
  "js-sys",
- "sourcefile",
  "wasm-bindgen",
- "wasm-bindgen-webidl",
-]
-
-[[package]]
-name = "weedle"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
-dependencies = [
- "nom",
 ]
 
 [[package]]

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -16,12 +16,12 @@ default = ["wasm-bindgen"]
 [dependencies]
 gc = "0.3.3"
 gc_derive = "0.3.2"
-serde_json = "1.0.46"
+serde_json = "1.0.48"
 rand = "0.7.3"
-regex = "1.3.4"
+regex = "1.3.5"
 
 # Optional Dependencies
-wasm-bindgen = { version = "0.2.58", optional = true }
+wasm-bindgen = { version = "0.2.59", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -16,13 +16,10 @@ pub fn construct_boolean(this: &Value, args: &[Value], _: &mut Interpreter) -> R
     this.set_kind(ObjectKind::Boolean);
 
     // Get the argument, if any
-    match args.get(0) {
-        Some(ref value) => {
-            this.set_internal_slot("BooleanData", to_boolean(value));
-        }
-        None => {
-            this.set_internal_slot("BooleanData", to_boolean(&to_value(false)));
-        }
+    if let Some(ref value) = args.get(0) {
+        this.set_internal_slot("BooleanData", to_boolean(value));
+    } else {
+        this.set_internal_slot("BooleanData", to_boolean(&to_value(false)));
     }
 
     // no need to return `this` as its passed by reference

--- a/boa/src/builtins/console.rs
+++ b/boa/src/builtins/console.rs
@@ -1,11 +1,14 @@
-use crate::builtins::function::NativeFunctionData;
-use crate::builtins::value::{
-    from_value, log_string_from, to_value, ResultValue, Value, ValueData,
+#![allow(clippy::print_stdout)]
+
+use crate::{
+    builtins::{
+        function::NativeFunctionData,
+        value::{from_value, log_string_from, to_value, ResultValue, Value, ValueData},
+    },
+    exec::Interpreter,
 };
-use crate::exec::Interpreter;
 use gc::Gc;
-use std::iter::FromIterator;
-use std::ops::Deref;
+use std::{iter::FromIterator, ops::Deref};
 
 /// Print a javascript value to the standard output stream
 /// <https://console.spec.whatwg.org/#logger>

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -108,7 +108,6 @@ pub fn to_locale_string(this: &Value, _args: &[Value], _ctx: &mut Interpreter) -
 ///
 /// https://tc39.es/ecma262/#sec-number.prototype.toprecision
 pub fn to_precision(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
-    println!("Number::to_precision()");
     let this_num = to_number(this);
     let _num_str_len = format!("{}", this_num.to_num()).len();
     let _precision = match args.get(0) {
@@ -119,7 +118,7 @@ pub fn to_precision(this: &Value, args: &[Value], _ctx: &mut Interpreter) -> Res
         None => 0,
     };
     // TODO: Implement toPrecision
-    unimplemented!();
+    unimplemented!("TODO: Implement toPrecision");
 }
 
 /// Number().toString()

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -850,10 +850,9 @@ impl Display for ValueData {
                 Function::NativeFunc(_) => write!(f, "function() {{ [native code] }}"),
                 Function::RegularFunc(ref rf) => {
                     write!(f, "function{}(", if rf.args.is_empty() { "" } else { " " })?;
-                    let last_index = rf.args.len() - 1;
                     for (index, arg) in rf.args.iter().enumerate() {
                         write!(f, "{}", arg)?;
-                        if index != last_index {
+                        if index + 1 != rf.args.len() {
                             write!(f, ", ")?;
                         }
                     }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -57,17 +57,14 @@ pub enum ValueData {
 impl ValueData {
     /// Returns a new empty object
     pub fn new_obj(global: Option<&Value>) -> Value {
-        match global {
-            Some(glob) => {
-                let obj_proto = glob.get_field_slice("Object").get_field_slice(PROTOTYPE);
+        if let Some(glob) = global {
+            let obj_proto = glob.get_field_slice("Object").get_field_slice(PROTOTYPE);
 
-                let obj = Object::create(obj_proto);
-                Gc::new(ValueData::Object(GcCell::new(obj)))
-            }
-            None => {
-                let obj = Object::default();
-                Gc::new(ValueData::Object(GcCell::new(obj)))
-            }
+            let obj = Object::create(obj_proto);
+            Gc::new(ValueData::Object(GcCell::new(obj)))
+        } else {
+            let obj = Object::default();
+            Gc::new(ValueData::Object(GcCell::new(obj)))
         }
     }
 
@@ -341,15 +338,14 @@ impl ValueData {
                         };
 
                         // If the getter is populated, use that. If not use [[Value]] instead
-                        match prop_getter {
-                            Some(val) => val,
-                            None => {
-                                let val = prop
-                                    .value
-                                    .as_ref()
-                                    .expect("Could not get property as reference");
-                                val.clone()
-                            }
+                        if let Some(val) = prop_getter {
+                            val
+                        } else {
+                            let val = prop
+                                .value
+                                .as_ref()
+                                .expect("Could not get property as reference");
+                            val.clone()
                         }
                     }
                     None => Gc::new(ValueData::Undefined),
@@ -789,39 +785,37 @@ fn display_obj(v: &ValueData, print_internals: bool) -> String {
         indent: usize,
         print_internals: bool,
     ) -> String {
-        match *data {
-            ValueData::Object(ref v) => {
-                // The in-memory address of the current object
-                let addr = address_of(v.borrow().deref());
+        if let ValueData::Object(ref v) = *data {
+            // The in-memory address of the current object
+            let addr = address_of(v.borrow().deref());
 
-                // We need not continue if this object has already been
-                // printed up the current chain
-                if encounters.contains(&addr) {
-                    return String::from("[Cycle]");
-                }
-
-                // Mark the current object as encountered
-                encounters.insert(addr);
-
-                let result = if print_internals {
-                    print_obj_value!(all of v, display_obj_internal, indent, encounters).join(",\n")
-                } else {
-                    print_obj_value!(props of v, display_obj_internal, indent, encounters, print_internals)
-                        .join(",\n")
-                };
-
-                // If the current object is referenced in a different branch,
-                // it will not cause an infinte printing loop, so it is safe to be printed again
-                encounters.remove(&addr);
-
-                let closing_indent = String::from_utf8(vec![b' '; indent.wrapping_sub(4)])
-                    .expect("Could not create the closing brace's indentation string");
-
-                format!("{{\n{}\n{}}}", result, closing_indent)
+            // We need not continue if this object has already been
+            // printed up the current chain
+            if encounters.contains(&addr) {
+                return String::from("[Cycle]");
             }
 
+            // Mark the current object as encountered
+            encounters.insert(addr);
+
+            let result = if print_internals {
+                print_obj_value!(all of v, display_obj_internal, indent, encounters).join(",\n")
+            } else {
+                print_obj_value!(props of v, display_obj_internal, indent, encounters, print_internals)
+                        .join(",\n")
+            };
+
+            // If the current object is referenced in a different branch,
+            // it will not cause an infinte printing loop, so it is safe to be printed again
+            encounters.remove(&addr);
+
+            let closing_indent = String::from_utf8(vec![b' '; indent.wrapping_sub(4)])
+                .expect("Could not create the closing brace's indentation string");
+
+            format!("{{\n{}\n{}}}", result, closing_indent)
+        } else {
             // Every other type of data is printed as is
-            _ => format!("{}", data),
+            format!("{}", data)
         }
     }
 
@@ -829,7 +823,7 @@ fn display_obj(v: &ValueData, print_internals: bool) -> String {
 }
 
 impl Display for ValueData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ValueData::Null => write!(f, "null"),
             ValueData::Undefined => write!(f, "undefined"),
@@ -855,7 +849,7 @@ impl Display for ValueData {
             ValueData::Function(ref v) => match *v.borrow() {
                 Function::NativeFunc(_) => write!(f, "function() {{ [native code] }}"),
                 Function::RegularFunc(ref rf) => {
-                    write!(f, "function(")?;
+                    write!(f, "function{}(", if rf.args.is_empty() { "" } else { " " })?;
                     let last_index = rf.args.len() - 1;
                     for (index, arg) in rf.args.iter().enumerate() {
                         write!(f, "{}", arg)?;
@@ -863,7 +857,7 @@ impl Display for ValueData {
                             write!(f, ", ")?;
                         }
                     }
-                    write!(f, "){}", rf.node)
+                    write!(f, ") {}", rf.node)
                 }
             },
         }

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -80,12 +80,11 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
 
     fn initialize_binding(&mut self, name: &str, value: Value) {
         if let Some(ref mut record) = self.env_rec.get_mut(name) {
-            match record.value {
-                Some(_) => {
-                    // TODO: change this when error handling comes into play
-                    panic!("Identifier {} has already been defined", name);
-                }
-                None => record.value = Some(value),
+            if record.value.is_none() {
+                record.value = Some(value);
+            } else {
+                // TODO: change this when error handling comes into play
+                panic!("Identifier {} has already been defined", name);
             }
         }
     }
@@ -121,16 +120,15 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
     }
 
     fn get_binding_value(&self, name: &str, _strict: bool) -> Value {
-        match self.env_rec.get(name) {
-            Some(binding) => binding
+        if let Some(binding) = self.env_rec.get(name) {
+            binding
                 .value
                 .as_ref()
                 .expect("Could not get record as reference")
-                .clone(),
-            None => {
-                // TODO: change this when error handling comes into play
-                panic!("ReferenceError: Cannot get binding value for {}", name);
-            }
+                .clone()
+        } else {
+            // TODO: change this when error handling comes into play
+            panic!("ReferenceError: Cannot get binding value for {}", name);
         }
     }
 

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -179,16 +179,15 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
     }
 
     fn get_binding_value(&self, name: &str, _strict: bool) -> Value {
-        match self.env_rec.get(name) {
-            Some(binding) => binding
+        if let Some(binding) = self.env_rec.get(name) {
+            binding
                 .value
                 .as_ref()
                 .expect("Could not get record as reference")
-                .clone(),
-            None => {
-                // TODO: change this when error handling comes into play
-                panic!("ReferenceError: Cannot get binding value for {}", name);
-            }
+                .clone()
+        } else {
+            // TODO: change this when error handling comes into play
+            panic!("ReferenceError: Cannot get binding value for {}", name);
         }
     }
 

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -61,7 +61,7 @@ impl EnvironmentError {
 }
 
 impl fmt::Display for EnvironmentError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.details)
     }
 }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -1,6 +1,30 @@
-#![deny(unused_qualifications, clippy::correctness, clippy::style)]
-#![warn(clippy::perf)]
-#![allow(clippy::cognitive_complexity)]
+#![deny(
+    unused_qualifications,
+    clippy::all,
+    unused_qualifications,
+    unused_import_braces,
+    unused_lifetimes,
+    unreachable_pub,
+    trivial_numeric_casts,
+    rustdoc,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    deprecated_in_future,
+    meta_variable_misuse,
+    non_ascii_idents,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style
+)]
+#![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    clippy::cognitive_complexity,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::as_conversions
+)]
 
 pub mod builtins;
 pub mod environment;

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -19,7 +19,7 @@ pub enum Const {
 }
 
 impl Display for Const {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match *self {
             Const::String(ref st) => write!(f, "\"{}\"", st),
             Const::Num(num) => write!(f, "{}", num),

--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -85,7 +85,7 @@ pub enum Keyword {
 #[derive(Debug, Clone, Copy)]
 pub struct KeywordError;
 impl Display for KeywordError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(f, "invalid token")
     }
 }
@@ -146,7 +146,7 @@ impl FromStr for Keyword {
     }
 }
 impl Display for Keyword {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             f,
             "{}",

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -31,7 +31,7 @@ pub enum NumOp {
 }
 
 impl Display for NumOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -76,8 +76,8 @@ pub enum UnaryOp {
     ///
     /// Unlike what common belief suggests, the delete operator has nothing to do with
     /// directly freeing memory. Memory management is done indirectly via breaking references.
-    /// If no more references to the same property are held, it is eventually released automatically. 
-    /// 
+    /// If no more references to the same property are held, it is eventually released automatically.
+    ///
     /// The `delete` operator returns `true` for all cases except when the property is an
     /// [own](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty)
     /// [non-configurable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_delete)
@@ -85,7 +85,7 @@ pub enum UnaryOp {
     ///
     /// For more information, please check: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete>
     Delete,
-    
+
     /// The `void` operator evaluates the given `expression` and then returns `undefined`.
     ///
     /// This operator allows evaluating expressions that produce a value into places where an
@@ -101,7 +101,7 @@ pub enum UnaryOp {
 }
 
 impl Display for UnaryOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -139,7 +139,7 @@ pub enum BitOp {
 }
 
 impl Display for BitOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -177,7 +177,7 @@ pub enum CompOp {
 }
 
 impl Display for CompOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -205,7 +205,7 @@ pub enum LogOp {
 }
 
 impl Display for LogOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -261,7 +261,7 @@ impl Operator for BinOp {
 }
 
 impl Display for BinOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -305,7 +305,7 @@ pub enum AssignOp {
 }
 
 impl Display for AssignOp {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",

--- a/boa/src/syntax/ast/punc.rs
+++ b/boa/src/syntax/ast/punc.rs
@@ -113,7 +113,7 @@ pub enum Punctuator {
 impl Punctuator {
     /// as_binop will attempt to convert a punctuator (+=) to a Binary Operator   
     /// If there is no match None will be returned
-    pub fn as_binop(&self) -> Option<BinOp> {
+    pub fn as_binop(self) -> Option<BinOp> {
         match self {
             Punctuator::Add => Some(BinOp::Num(NumOp::Add)),
             Punctuator::Sub => Some(BinOp::Num(NumOp::Sub)),
@@ -142,7 +142,7 @@ impl Punctuator {
 }
 
 impl Display for Punctuator {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             f,
             "{}",

--- a/boa/src/syntax/ast/token.rs
+++ b/boa/src/syntax/ast/token.rs
@@ -22,7 +22,7 @@ impl Token {
 }
 
 impl Display for Token {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.kind)
     }
 }
@@ -30,7 +30,7 @@ impl Display for Token {
 pub struct VecToken(Vec<Token>);
 
 impl Debug for VecToken {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut buffer = String::new();
         for token in &self.0 {
             buffer.push_str(&token.to_string());
@@ -67,7 +67,7 @@ pub enum TokenKind {
 }
 
 impl Display for TokenKind {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match *self {
             TokenKind::BooleanLiteral(ref val) => write!(f, "{}", val),
             TokenKind::EOF => write!(f, "end of file"),

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -84,7 +84,7 @@ impl LexerError {
 }
 
 impl fmt::Display for LexerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.details)
     }
 }
@@ -423,7 +423,7 @@ impl<'a> Lexer<'a> {
                         }
                     };
 
-                    self.push_token(TokenKind::NumericLiteral(num as f64));
+                    self.push_token(TokenKind::NumericLiteral(num));
 
                     //11.8.3
                     if let Err(e) = self.check_after_numeric_literal() {

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 
 [dependencies]
 Boa = { path = "../boa", default-features = false }
-structopt = "0.3.9"
+structopt = "0.3.12"


### PR DESCRIPTION
This PR is to the `parser` branch, in order to keep developing the new parser in #281 .

I added indentation for the `fmt::Display` implementation in AST nodes, and also improved greatly how the final code looks. It should look pretty close to how a programmer would write it.

I also took the opportunity to fix a bunch of warnings. Some of them were showing in the builds, some of them were silenced. I added some extra lints in order to find them.

There are only a couple of warnings left: the usage of the `dbg!()` macro, that in my personal opinion should be a warning (we should remove the usage of the macro before merging into production) and a couple of unused methods, that should be removed in the case we end up not needing them.

Let me know if you want any change.