### PR TITLE
New parser fixes tests failing against #281

### DIFF
--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -19,11 +19,11 @@ gc = "0.3.3"
 gc_derive = "0.3.2"
 serde_json = "1.0.48"
 rand = "0.7.3"
-regex = "1.3.5"
+regex = "1.3.6"
 
 # Optional Dependencies
 wasm-bindgen = { version = "0.2.59", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0.105", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -11,7 +11,7 @@ fn is_array() {
         var new_arr = new Array();
         var many = ["a", "b", "c"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "Array.isArray(empty)"), "true");
     assert_eq!(forward(&mut engine, "Array.isArray(new_arr)"), "true");
     assert_eq!(forward(&mut engine, "Array.isArray(many)"), "true");
@@ -51,7 +51,7 @@ fn concat() {
     // var empty = new Array();
     // var one = new Array(1);
     // "#;
-    // forward(&mut engine, init);
+    // eprintln!("{}", forward(&mut engine, init));
     // // Empty ++ Empty
     // let ee = forward(&mut engine, "empty.concat(empty)");
     // assert_eq!(ee, String::from("[]"));
@@ -75,7 +75,7 @@ fn join() {
         var one = ["a"];
         var many = ["a", "b", "c"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     // Empty
     let empty = forward(&mut engine, "empty.join('.')");
     assert_eq!(empty, String::from(""));
@@ -96,7 +96,7 @@ fn to_string() {
         var one = ["a"];
         var many = ["a", "b", "c"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     // Empty
     let empty = forward(&mut engine, "empty.toString()");
     assert_eq!(empty, String::from(""));
@@ -136,7 +136,7 @@ fn every() {
           return elem < 3;
         }
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let result = forward(&mut engine, "array.every(callback);");
     assert_eq!(result, "true");
 
@@ -163,7 +163,7 @@ fn find() {
         }
         var many = ["a", "b", "c"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let found = forward(&mut engine, "many.find(comp)");
     assert_eq!(found, String::from("a"));
 }
@@ -201,7 +201,7 @@ fn push() {
     let init = r#"
         var arr = [1, 2];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(forward(&mut engine, "arr.push()"), "2");
     assert_eq!(forward(&mut engine, "arr.push(3, 4)"), "4");
@@ -218,7 +218,7 @@ fn pop() {
         var one = [1];
         var many = [1, 2, 3, 4];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(
         forward(&mut engine, "empty.pop()"),
@@ -240,7 +240,7 @@ fn shift() {
         var one = [1];
         var many = [1, 2, 3, 4];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(
         forward(&mut engine, "empty.shift()"),
@@ -260,7 +260,7 @@ fn unshift() {
     let init = r#"
         var arr = [3, 4];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(forward(&mut engine, "arr.unshift()"), "2");
     assert_eq!(forward(&mut engine, "arr.unshift(1, 2)"), "4");
@@ -276,7 +276,7 @@ fn reverse() {
         var arr = [1, 2];
         var reversed = arr.reverse();
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "reversed[0]"), "2");
     assert_eq!(forward(&mut engine, "reversed[1]"), "1");
     assert_eq!(forward(&mut engine, "arr[0]"), "2");
@@ -293,7 +293,7 @@ fn index_of() {
         var many = ["a", "b", "c"];
         var duplicates = ["a", "b", "c", "a", "b"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     // Empty
     let empty = forward(&mut engine, "empty.indexOf('a')");
@@ -357,7 +357,7 @@ fn last_index_of() {
         var many = ["a", "b", "c"];
         var duplicates = ["a", "b", "c", "a", "b"];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     // Empty
     let empty = forward(&mut engine, "empty.lastIndexOf('a')");
@@ -509,7 +509,7 @@ fn fill() {
 }
 
 #[test]
-fn inclues_value() {
+fn includes_value() {
     let realm = Realm::create();
     let mut engine = Executor::new(realm);
     let init = r#"
@@ -519,7 +519,7 @@ fn inclues_value() {
         var duplicates = ["a", "b", "c", "a", "b"];
         var undefined = [undefined];
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     // Empty
     let empty = forward(&mut engine, "empty.includes('a')");
@@ -619,7 +619,7 @@ fn slice() {
         var many2 = ["a", "b", "c", "d"].slice(2, 3);
         var many3 = ["a", "b", "c", "d"].slice(7);
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(forward(&mut engine, "empty.length"), "0");
     assert_eq!(forward(&mut engine, "one[0]"), "a");
@@ -648,7 +648,7 @@ fn for_each() {
         }
         a.forEach(callingCallback);
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     assert_eq!(forward(&mut engine, "sum"), "14");
     assert_eq!(forward(&mut engine, "indexSum"), "6");
@@ -666,7 +666,7 @@ fn for_each_push_value() {
         }
         a.forEach(callingCallback);
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     // [ 1, 2, 3, 4, 2, 4, 6, 8 ]
     assert_eq!(forward(&mut engine, "a.length"), "8");

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -20,7 +20,7 @@ fn construct_and_call() {
         var one = new Boolean(1);
         var zero = Boolean(0);
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let one = forward_val(&mut engine, "one").unwrap();
     let zero = forward_val(&mut engine, "zero").unwrap();
 
@@ -39,7 +39,7 @@ fn constructor_gives_true_instance() {
         var trueBool = new Boolean(trueVal);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let true_val = forward_val(&mut engine, "trueVal").expect("value expected");
     let true_num = forward_val(&mut engine, "trueNum").expect("value expected");
     let true_string = forward_val(&mut engine, "trueString").expect("value expected");
@@ -67,7 +67,7 @@ fn instances_have_correct_proto_set() {
         var boolProto = Boolean.prototype;
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let bool_instance = forward_val(&mut engine, "boolInstance").expect("value expected");
     let bool_prototype = forward_val(&mut engine, "boolProto").expect("value expected");
 

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -61,8 +61,8 @@ impl RegularFunction {
     }
 }
 
-#[derive(Finalize, Clone)]
 /// Represents a native javascript function in memory
+#[derive(Finalize, Clone)]
 pub struct NativeFunction {
     /// The fields associated with the function
     pub object: Object,

--- a/boa/src/builtins/function/tests.rs
+++ b/boa/src/builtins/function/tests.rs
@@ -14,7 +14,7 @@ fn check_arguments_object() {
         var val = jason(100, 6);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let expected_return_val: f64 = 100.0;
     let return_val = forward_val(&mut engine, "val").expect("value expected");
     assert_eq!(return_val.is_double(), true);

--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -10,7 +10,7 @@ fn abs() {
         var b = Math.abs(1.23456 - 7.89012);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -30,7 +30,7 @@ fn acos() {
         var d = Math.acos(2);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward(&mut engine, "b");
@@ -53,7 +53,7 @@ fn acosh() {
         var c = Math.acosh(0.5);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward(&mut engine, "b");
@@ -73,7 +73,7 @@ fn asin() {
         var b = Math.asin(5 / 3);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward(&mut engine, "b");
@@ -91,7 +91,7 @@ fn asinh() {
         var b = Math.asinh(0);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -110,7 +110,7 @@ fn atan() {
         var c = Math.atan(-0);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -130,7 +130,7 @@ fn atan2() {
         var b = Math.atan2(15, 90);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -149,7 +149,7 @@ fn cbrt() {
         var c = Math.cbrt(1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -170,7 +170,7 @@ fn ceil() {
         var c = Math.ceil(-7.004);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -190,7 +190,7 @@ fn cos() {
         var b = Math.cos(1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -209,7 +209,7 @@ fn cosh() {
         var c = Math.cosh(-1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -230,7 +230,7 @@ fn exp() {
         var c = Math.exp(2);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -251,7 +251,7 @@ fn floor() {
         var c = Math.floor(3.01);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -272,7 +272,7 @@ fn log() {
         var c = Math.log(-1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -293,7 +293,7 @@ fn log10() {
         var c = Math.log10(-2);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -314,7 +314,7 @@ fn log2() {
         var c = Math.log2(-2);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -335,7 +335,7 @@ fn max() {
         var c = Math.max(-10, 20); 
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -356,7 +356,7 @@ fn min() {
         var c = Math.min(-10, 20); 
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -378,7 +378,7 @@ fn pow() {
         var d = Math.pow(7, -2);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -400,7 +400,7 @@ fn round() {
         var b = Math.round(-20.3);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -419,7 +419,7 @@ fn sign() {
         var c = Math.sign(0); 
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -439,7 +439,7 @@ fn sin() {
         var b = Math.sin(1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -457,7 +457,7 @@ fn sinh() {
         var b = Math.sinh(1);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -476,7 +476,7 @@ fn sqrt() {
         var c = Math.sqrt(9);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -497,7 +497,7 @@ fn sqrt() {
 //         var a = Math.tan(1.1);
 //         "#;
 
-//     forward(&mut engine, init);
+//     eprintln!("{}", forward(&mut engine, init));
 
 //     let a = forward_val(&mut engine, "a").unwrap();
 
@@ -513,7 +513,7 @@ fn tanh() {
         var b = Math.tanh(0);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();
@@ -531,7 +531,7 @@ fn trunc() {
         var b = Math.trunc(0.123);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let a = forward_val(&mut engine, "a").unwrap();
     let b = forward_val(&mut engine, "b").unwrap();

--- a/boa/src/builtins/number/tests.rs
+++ b/boa/src/builtins/number/tests.rs
@@ -24,7 +24,7 @@ fn call_number() {
         var from_exp = Number("2.34e+2");
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_zero = forward_val(&mut engine, "default_zero").unwrap();
     let int_one = forward_val(&mut engine, "int_one").unwrap();
     let float_two = forward_val(&mut engine, "float_two").unwrap();
@@ -57,7 +57,7 @@ fn to_exponential() {
         var noop_exp = Number("1.23e+2").toExponential();
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_exp = forward(&mut engine, "default_exp");
     let int_exp = forward(&mut engine, "int_exp");
     let float_exp = forward(&mut engine, "float_exp");
@@ -85,7 +85,7 @@ fn to_fixed() {
         var nan_fixed = Number("I am not a number").toFixed();
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_fixed = forward(&mut engine, "default_fixed");
     let pos_fixed = forward(&mut engine, "pos_fixed");
     let neg_fixed = forward(&mut engine, "neg_fixed");
@@ -113,7 +113,7 @@ fn to_locale_string() {
     // TODO: We don't actually do any locale checking here
     // To honor the spec we should print numbers according to user locale.
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_locale = forward(&mut engine, "default_locale");
     let small_locale = forward(&mut engine, "small_locale");
     let big_locale = forward(&mut engine, "big_locale");
@@ -139,7 +139,7 @@ fn to_precision() {
         var neg_precision = Number(-123456789).toPrecision(4);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_precision = forward(&mut engine, "default_precision");
     let low_precision = forward(&mut engine, "low_precision");
     let more_precision = forward(&mut engine, "more_precision");
@@ -170,7 +170,7 @@ fn to_string() {
         var neg_string = Number(-1.2).toString();
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_string = forward(&mut engine, "default_string");
     let int_string = forward(&mut engine, "int_string");
     let float_string = forward(&mut engine, "float_string");
@@ -198,7 +198,7 @@ fn value_of() {
         var neg_val = Number("-1.2e+4").valueOf()
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let default_val = forward_val(&mut engine, "default_val").unwrap();
     let int_val = forward_val(&mut engine, "int_val").unwrap();
     let float_val = forward_val(&mut engine, "float_val").unwrap();

--- a/boa/src/builtins/regexp/tests.rs
+++ b/boa/src/builtins/regexp/tests.rs
@@ -13,7 +13,7 @@ fn test_constructors() {
         var ctor_literal = new RegExp(/[0-9]+(\.[0-9]+)?/);
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "constructed.test('1.0')"), "true");
     assert_eq!(forward(&mut engine, "literal.test('1.0')"), "true");
     assert_eq!(forward(&mut engine, "ctor_literal.test('1.0')"), "true");
@@ -36,7 +36,7 @@ fn check_regexp_constructor_is_function() {
 //                var re_sm = /test/sm;
 //                "#;
 //
-//        forward(&mut engine, init);
+//        eprintln!("{}", forward(&mut engine, init));
 //        assert_eq!(forward(&mut engine, "re_gi.global"), "true");
 //        assert_eq!(forward(&mut engine, "re_gi.ignoreCase"), "true");
 //        assert_eq!(forward(&mut engine, "re_gi.multiline"), "false");
@@ -62,7 +62,7 @@ fn test_last_index() {
         var regex = /[0-9]+(\.[0-9]+)?/g;
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "regex.lastIndex"), "0");
     assert_eq!(forward(&mut engine, "regex.test('1.0foo')"), "true");
     assert_eq!(forward(&mut engine, "regex.lastIndex"), "3");
@@ -79,7 +79,7 @@ fn test_exec() {
         var result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "result[0]"), "Quick Brown Fox Jumps");
     assert_eq!(forward(&mut engine, "result[1]"), "Brown");
     assert_eq!(forward(&mut engine, "result[2]"), "Jumps");

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -21,7 +21,7 @@ fn check_string_constructor_is_function() {
 //     const c = new String(' \b ');
 //     cosnt d = new String('中文长度')
 //     "#;
-//     forward(&mut engine, init);
+//     eprintln!("{}", forward(&mut engine, init));
 //     let a = forward(&mut engine, "a.length");
 //     assert_eq!(a, String::from("1"));
 //     let b = forward(&mut engine, "b.length");
@@ -44,7 +44,7 @@ fn concat() {
         var world = new String('world! ');
         var nice = new String('Have a nice day.');
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     // Todo: fix this
     let _a = forward(&mut engine, "hello.concat(world, nice)");
@@ -63,7 +63,7 @@ fn construct_and_call() {
         var hello = new String('Hello');
         var world = String('world');
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let hello = forward_val(&mut engine, "hello").unwrap();
     let world = forward_val(&mut engine, "world").unwrap();
 
@@ -80,7 +80,7 @@ fn repeat() {
         var en = new String('english');
         var zh = new String('中文');
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let empty = String::from("");
     assert_eq!(forward(&mut engine, "empty.repeat(0)"), empty);
@@ -108,7 +108,7 @@ fn replace() {
         a = a.replace("a", "2");
         a
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
 
     let empty = String::from("2bc");
     assert_eq!(forward(&mut engine, "a"), empty);
@@ -131,7 +131,7 @@ fn replace_with_function() {
         a = a.replace(/c(o)(o)(l)/, replacer);
         a;
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(
         forward(&mut engine, "a"),
         String::from("ecmascript is awesome!")
@@ -155,7 +155,7 @@ fn starts_with() {
         var enLiteral = 'english';
         var zhLiteral = '中文';
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let pass = String::from("true");
     assert_eq!(forward(&mut engine, "empty.startsWith('')"), pass);
     assert_eq!(forward(&mut engine, "en.startsWith('e')"), pass);
@@ -179,7 +179,7 @@ fn ends_with() {
         var enLiteral = 'english';
         var zhLiteral = '中文';
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let pass = String::from("true");
     assert_eq!(forward(&mut engine, "empty.endsWith('')"), pass);
     assert_eq!(forward(&mut engine, "en.endsWith('h')"), pass);
@@ -250,7 +250,7 @@ fn match_all() {
         var str = 'table football, foosball';
         var matches = str.matchAll(regexp);
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(
         forward(&mut engine, "matches[0][0]"),
         String::from("football")
@@ -275,7 +275,7 @@ fn test_match() {
         var result4 = str.match(RegExp("B", 'g'));
         "#;
 
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "result1[0]"), "Quick Brown Fox Jumps");
     assert_eq!(forward(&mut engine, "result1[1]"), "Brown");
     assert_eq!(forward(&mut engine, "result1[2]"), "Jumps");

--- a/boa/src/builtins/symbol/tests.rs
+++ b/boa/src/builtins/symbol/tests.rs
@@ -17,7 +17,7 @@ fn call_symbol_and_check_return_type() {
     let init = r#"
         var sym = Symbol();
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let sym = forward_val(&mut engine, "sym").unwrap();
     assert_eq!(sym.is_symbol(), true);
 }
@@ -29,7 +29,7 @@ fn print_symbol_expect_description() {
     let init = r#"
         var sym = Symbol("Hello");
         "#;
-    forward(&mut engine, init);
+    eprintln!("{}", forward(&mut engine, init));
     let sym = forward_val(&mut engine, "sym.toString()").unwrap();
     assert_eq!(sym.to_string(), "Symbol(Hello)");
 }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -21,8 +21,8 @@ use std::{
     str::FromStr,
 };
 
-#[must_use]
 /// The result of a Javascript expression is represented like this so it can succeed (`Ok`) or fail (`Err`)
+#[must_use]
 pub type ResultValue = Result<Value, Value>;
 /// A Garbage-collected Javascript value as represented in the interpreter
 pub type Value = Gc<ValueData>;

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -208,12 +208,8 @@ impl LexicalEnvironment {
     }
 
     pub fn get_binding_value(&self, name: &str) -> Value {
-        dbg!(&name);
         self.environments()
-            .find(|env| {
-                dbg!(&env.borrow().has_binding(name));
-                env.borrow().has_binding(name)
-            })
+            .find(|env| env.borrow().has_binding(name))
             .map(|env| env.borrow().get_binding_value(name, false))
             .unwrap_or_else(|| Gc::new(ValueData::Undefined))
     }

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -208,8 +208,12 @@ impl LexicalEnvironment {
     }
 
     pub fn get_binding_value(&self, name: &str) -> Value {
+        dbg!(&name);
         self.environments()
-            .find(|env| env.borrow().has_binding(name))
+            .find(|env| {
+                dbg!(&env.borrow().has_binding(name));
+                env.borrow().has_binding(name)
+            })
             .map(|env| env.borrow().get_binding_value(name, false))
             .unwrap_or_else(|| Gc::new(ValueData::Undefined))
     }

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -511,7 +511,7 @@ impl Executor for Interpreter {
                     ValueData::String(_) => "string",
                     ValueData::Function(_) => "function",
                 }))
-            },
+            }
             Node::StatementList(ref list) => {
                 for (i, item) in list.iter().enumerate() {
                     if i + 1 == list.len() {
@@ -521,7 +521,7 @@ impl Executor for Interpreter {
                 }
 
                 Ok(Gc::new(ValueData::Undefined))
-            },
+            }
             _ => unimplemented!(),
         }
     }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -47,11 +47,10 @@ use crate::{
 pub use serde_json;
 
 fn parser_expr(src: &str) -> Result<Node, String> {
-    dbg!("test");
     let mut lexer = Lexer::new(src);
     lexer.lex().map_err(|e| format!("SyntaxError: {}", e))?;
     let tokens = lexer.tokens;
-    dbg!(&tokens);
+    // dbg!(&tokens);
     Parser::new(tokens)
         .parse_all()
         .map_err(|e| format!("ParsingError: {}", e))

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -3,10 +3,9 @@ use std::fmt::{Display, Formatter, Result};
 
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
-
+/// A Javascript Constant.
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A Javascript Constant
 pub enum Const {
     /// A UTF-8 string, such as `"Hello, world"`
     String(String),

--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -7,10 +7,11 @@ use std::{
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
 
+/// A Javascript Keyword
+///
+/// As specificed by <https://www.ecma-international.org/ecma-262/#sec-keywords>
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Debug)]
-/// A Javascript Keyword
-/// As specificed by <https://www.ecma-international.org/ecma-262/#sec-keywords>
 pub enum Keyword {
     /// The `await` keyword
     Await,

--- a/boa/src/syntax/ast/node.rs
+++ b/boa/src/syntax/ast/node.rs
@@ -7,9 +7,10 @@ use std::{collections::btree_map::BTreeMap, fmt};
 
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
+
+/// A Javascript AST Node.
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A Javascript AST Node.
 pub enum Node {
     /// Create an array with items inside.
     ArrayDecl(Vec<Node>),
@@ -37,9 +38,9 @@ pub enum Node {
     Continue(Option<String>),
     /// Create a function with the given name, arguments, and internal AST node.
     FunctionDecl(Option<String>, Vec<FormalParameter>, Box<Node>),
-    /// Gets the constant field of a value
+    /// Gets the constant field of a value.
     GetConstField(Box<Node>, String),
-    /// Gets the [field] of a value
+    /// Gets the [field] of a value.
     GetField(Box<Node>, Box<Node>),
     /// [init], [cond], [step], body
     ForLoop(

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -16,9 +16,9 @@ pub trait Operator {
     }
 }
 
+/// A numeric operation between 2 values
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A numeric operation between 2 values
 pub enum NumOp {
     /// `a + b` - Addition
     Add,
@@ -51,11 +51,11 @@ impl Display for NumOp {
     }
 }
 
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 /// A unary operation on a single value
 ///
 /// For more information, please check: <https://tc39.es/ecma262/#prod-UnaryExpression>
+#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum UnaryOp {
     /// `a++` - increment the value
     IncrementPost,
@@ -126,9 +126,9 @@ impl Display for UnaryOp {
     }
 }
 
+/// A bitwise operation between 2 values
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A bitwise operation between 2 values
 pub enum BitOp {
     /// `a & b` - Bitwise and
     And,
@@ -161,9 +161,9 @@ impl Display for BitOp {
     }
 }
 
+/// A comparitive operation between 2 values
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A comparitive operation between 2 values
 pub enum CompOp {
     /// `a == b` - Equality
     Equal,
@@ -202,9 +202,9 @@ impl Display for CompOp {
     }
 }
 
+/// A logical operation between 2 boolean values
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A logical operation between 2 boolean values
 pub enum LogOp {
     /// `a && b` - Logical and
     And,
@@ -225,9 +225,9 @@ impl Display for LogOp {
     }
 }
 
+/// A binary operation between 2 values
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A binary operation between 2 values
 pub enum BinOp {
     /// Numeric operation
     Num(NumOp),
@@ -285,10 +285,11 @@ impl Display for BinOp {
     }
 }
 
+/// A binary operation between 2 values
+///
+/// <https://tc39.es/ecma262/#prod-AssignmentOperator>
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
-/// A binary operation between 2 values
-/// https://tc39.es/ecma262/#prod-AssignmentOperator
 pub enum AssignOp {
     /// `a += b` - Add assign
     Add,

--- a/boa/src/syntax/ast/pos.rs
+++ b/boa/src/syntax/ast/pos.rs
@@ -1,13 +1,14 @@
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, PartialEq, Debug)]
 /// A position in the Javascript source code
+///
 /// Stores both the column number and the line number
 ///
 /// ## Similar Implementations
 /// [V8: Location](https://cs.chromium.org/chromium/src/v8/src/parsing/scanner.h?type=cs&q=isValid+Location&g=0&l=216)
+#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Position {
     // Column number
     pub column_number: u64,

--- a/boa/src/syntax/ast/pos.rs
+++ b/boa/src/syntax/ast/pos.rs
@@ -17,9 +17,9 @@ pub struct Position {
 }
 
 impl Position {
-    /// Creates a new position
+    /// Creates a new `Position`.
     ///
-    /// Positions are usually created by a [Token](struct.token/Token.html).
+    /// Positions are usually created by a [`Token`](struct.token/Token.html).
     ///
     /// # Arguments
     ///

--- a/boa/src/syntax/ast/pos.rs
+++ b/boa/src/syntax/ast/pos.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
 
-/// A position in the Javascript source code
+/// A position in the Javascript source code.
 ///
 /// Stores both the column number and the line number
 ///
@@ -17,9 +17,9 @@ pub struct Position {
 }
 
 impl Position {
-    /// Create a new position, positions are usually created by Tokens..
+    /// Creates a new position
     ///
-    /// See [Token](struct.token/Token.html) for example usage
+    /// Positions are usually created by a [Token](struct.token/Token.html).
     ///
     /// # Arguments
     ///

--- a/boa/src/syntax/ast/punc.rs
+++ b/boa/src/syntax/ast/punc.rs
@@ -115,8 +115,9 @@ pub enum Punctuator {
 }
 
 impl Punctuator {
-    /// as_binop will attempt to convert a punctuator (+=) to a Binary Operator
-    /// If there is no match None will be returned
+    /// Attempts to convert a punctuator (`+`, `=`...) to a Binary Operator
+    ///
+    /// If there is no match, `None` will be returned.
     pub fn as_binop(self) -> Option<BinOp> {
         match self {
             Punctuator::Add => Some(BinOp::Num(NumOp::Add)),

--- a/boa/src/syntax/ast/punc.rs
+++ b/boa/src/syntax/ast/punc.rs
@@ -4,9 +4,9 @@ use std::fmt::{Display, Error, Formatter};
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
 
+/// Punctuation
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Clone, Copy, Debug)]
-/// Punctuation
 pub enum Punctuator {
     /// `+`
     Add,
@@ -115,7 +115,7 @@ pub enum Punctuator {
 }
 
 impl Punctuator {
-    /// as_binop will attempt to convert a punctuator (+=) to a Binary Operator   
+    /// as_binop will attempt to convert a punctuator (+=) to a Binary Operator
     /// If there is no match None will be returned
     pub fn as_binop(self) -> Option<BinOp> {
         match self {

--- a/boa/src/syntax/ast/token.rs
+++ b/boa/src/syntax/ast/token.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display, Formatter, Result};
 #[cfg(feature = "serde-ast")]
 use serde::{Deserialize, Serialize};
 
-/// Represents a token
+/// Represents a token.
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Token {
@@ -41,9 +41,10 @@ impl Debug for VecToken {
         write!(f, "{}", buffer)
     }
 }
+
+/// Represents the type of Token and the data it has inside.
 #[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
-/// Represents the type of Token and the data it has inside.
 pub enum TokenKind {
     /// A boolean literal, which is either `true` or `false`
     BooleanLiteral(bool),

--- a/boa/src/syntax/ast/token.rs
+++ b/boa/src/syntax/ast/token.rs
@@ -85,7 +85,7 @@ impl Display for TokenKind {
                 write!(f, "/{}/{}", body, flags)
             }
             TokenKind::Comment(ref comm) => write!(f, "/*{}*/", comm),
-            TokenKind::LineTerminator => write!(f, "\\n"),
+            TokenKind::LineTerminator => write!(f, "line terminator"),
         }
     }
 }

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -673,9 +673,9 @@ impl<'a> Lexer<'a> {
                 ),
                 '~' => self.push_punc(Punctuator::Neg),
                 '\n' | '\u{2028}' | '\u{2029}' => {
+                    self.push_token(TokenKind::LineTerminator);
                     self.line_number += 1;
                     self.column_number = 0;
-                    self.push_token(TokenKind::LineTerminator);
                 }
                 '\r' => {
                     self.column_number = 0;

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -1133,8 +1133,9 @@ impl Parser {
         self.read_statements(true, true)
     }
 
-    /// Read a line of statements and stop after `}`   
-    /// Starts after `{`
+    /// Read a list of statements and stop after `}`
+    ///
+    /// Note: It starts after `{`.
     fn read_block(&mut self) -> Result<Node, ParseError> {
         self.read_statements(true, false)
     }
@@ -1286,7 +1287,7 @@ impl Parser {
 
         self.expect(
             TokenKind::Punctuator(Punctuator::OpenBracket),
-            "expected '{'",
+            "function declaration",
         )?;
 
         let body = self.read_block()?;

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -1286,7 +1286,7 @@ impl Parser {
         let params = self.read_formal_parameters()?;
 
         self.expect(
-            TokenKind::Punctuator(Punctuator::OpenBracket),
+            TokenKind::Punctuator(Punctuator::OpenBlock),
             "function declaration",
         )?;
 

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -244,11 +244,11 @@ impl Parser {
         }
     }
 
-    /// Peek the next token, if it's of `kind` type.
+    /// Gets the next token, if the current token is of `kind` type.
     ///
-    /// When the next token is a `kind` token, get the token, otherwise return `None`.
+    /// When the current token is a `kind` token, get the next token, otherwise return `None`.
     fn next_if(&mut self, kind: TokenKind) -> Option<Token> {
-        match self.peek(0) {
+        match self.get_current_token() {
             Ok(tok) => {
                 if tok.kind == kind {
                     Some(self.get_next_token().unwrap())


### PR DESCRIPTION
I have ported #261 to the new parser (#281) (this should close #261). And I'm working on fixing the tests that don't pass. I'm getting this error:
```
ParsingError: Unexpected Token 'empty' at line 1, col 13
```

When parsing:
```javascript
        var empty = [ ];
        var one = ["a"];
        var many = ["a", "b", "c"];
        var duplicates = ["a", "b", "c", "a", "b"];
```

So, I'll try to fix that variable creation tomorrow if possible. Feel free to add suggestions.