### PR TITLE
Added cursor to parser

### DIFF
--- a/boa/src/syntax/parser/cursor.rs
+++ b/boa/src/syntax/parser/cursor.rs
@@ -28,16 +28,8 @@ impl Cursor {
     }
 
     /// Moves the cursor to the given position.
-    ///
     /// This is intended to be used *always* with `Cursor::pos()`.
     ///
-    /// # Example:
-    /// ```
-    /// # let mut cursor = Cursor::new(Vec::new());
-    /// let pos_save = cursor.pos();
-    /// // Do some stuff that might change the cursor position...
-    /// cursor.seek(pos_save);
-    /// ```
     pub(super) fn seek(&mut self, pos: usize) {
         self.pos = pos
     }

--- a/boa/src/syntax/parser/cursor.rs
+++ b/boa/src/syntax/parser/cursor.rs
@@ -1,0 +1,88 @@
+//! Cursor implementation for the parser.
+
+use crate::syntax::ast::token::Token;
+
+/// Token cursor.
+///
+/// This internal structure gives basic testable operations to the parser.
+#[derive(Debug, Clone, Default)]
+pub struct Cursor {
+    /// The tokens being input.
+    tokens: Vec<Token>,
+    /// The current position within the tokens.
+    pos: usize,
+}
+
+impl Cursor {
+    /// Creates a new cursor.
+    pub fn new(tokens: Vec<Token>) -> Self {
+        Self {
+            tokens,
+            ..Self::default()
+        }
+    }
+
+    /// Moves the cursor to the next token and returns the token.
+    pub fn next(&mut self) -> Option<&Token> {
+        let token = self.tokens.get(self.pos);
+
+        if self.pos != self.tokens.len() {
+            self.pos += 1;
+        }
+
+        token
+    }
+
+    /// Moves the cursor to the next token after skipping tokens based on the predicate.
+    pub fn next_skip<P>(&mut self, skip: P) -> Option<&Token>
+    where
+        P: FnMut(&Token) -> bool,
+    {
+        while let Some(token) = self.next() {
+            if !skip(token) {
+                return Some(token);
+            }
+        }
+        None
+    }
+
+    /// Peeks the next token without moving the cursor.
+    pub fn peek(&self, skip: usize) -> Option<&Token> {
+        self.tokens.get(self.pos + skip)
+    }
+
+    /// Peeks the next token after skipping tokens based on the predicate.
+    pub fn peek_skip<P>(&self, skip: P) -> Option<&Token>
+    where
+        P: FnMut(&Token) -> bool,
+    {
+        let mut current = self.pos;
+        while let Some(token) = self.tokens.get(current) {
+            if !skip(token) {
+                return Some(token);
+            }
+            current += 1;
+        }
+
+        None
+    }
+
+    /// Moves the cursor to the previous token and returns the token.
+    pub fn prev(&mut self) -> Option<&Token> {
+        if self.pos == 0 {
+            None
+        } else {
+            self.pos -= 1;
+            self.tokens.get(self.pos)
+        }
+    }
+
+    /// Peeks the previous token without moving the cursor.
+    pub fn peek_prev(&self) -> Option<&Token> {
+        if self.pos == 0 {
+            None
+        } else {
+            self.tokens.get(self.pos - 1)
+        }
+    }
+}

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -1482,7 +1482,14 @@ impl Parser {
                 }
             }
 
-            args.push(self.read_assignment_expression()?);
+            if self
+                .next_if(TokenKind::Punctuator(Punctuator::Spread))
+                .is_some()
+            {
+                args.push(Node::Spread(Box::new(self.read_assignment_expression()?)));
+            } else {
+                args.push(self.read_assignment_expression()?);
+            }
         }
 
         Ok(args)


### PR DESCRIPTION
This adds a simple cursor structure to the new parser (#281), which enables doing simpler operations, and making it easier to understand.

This also brings token referencing to the parser, to avoid so much cloning. Most of the cloning only happens when we need to return an error, in which case, it doesn't matter if it takes us a bit more. But for the rest, I think this should be faster. This closes #284.

I also took the opportunity to improve a bit further the documentation and the parser errors.