### PR TITLE
Changed Cursor to take in a &[Token].

### DIFF
--- a/boa/benches/parser.rs
+++ b/boa/benches/parser.rs
@@ -19,7 +19,7 @@ fn expression_parser(c: &mut Criterion) {
         "Expression (Parser)",
         move |b, tok| {
             b.iter(|| {
-                Parser::new(black_box(tok.to_vec())).parse_all().unwrap();
+                Parser::new(&black_box(tok.to_vec())).parse_all().unwrap();
             })
         },
         vec![tokens],

--- a/boa/benches/string.rs
+++ b/boa/benches/string.rs
@@ -29,7 +29,7 @@ fn hello_world_parser(c: &mut Criterion) {
         "Hello World (Parser)",
         move |b, tok| {
             b.iter(|| {
-                Parser::new(black_box(tok.to_vec())).parse_all().unwrap();
+                Parser::new(&black_box(tok.to_vec())).parse_all().unwrap();
             })
         },
         vec![tokens],

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -51,7 +51,7 @@ fn parser_expr(src: &str) -> Result<Node, String> {
     lexer.lex().map_err(|e| format!("SyntaxError: {}", e))?;
     let tokens = lexer.tokens;
     // dbg!(&tokens);
-    Parser::new(tokens)
+    Parser::new(&tokens)
         .parse_all()
         .map_err(|e| format!("ParsingError: {}", e))
 }

--- a/boa/src/syntax/parser/cursor.rs
+++ b/boa/src/syntax/parser/cursor.rs
@@ -6,16 +6,16 @@ use crate::syntax::ast::token::Token;
 ///
 /// This internal structure gives basic testable operations to the parser.
 #[derive(Debug, Clone, Default)]
-pub(super) struct Cursor {
+pub(super) struct Cursor<'a> {
     /// The tokens being input.
-    tokens: Vec<Token>,
+    tokens: &'a [Token],
     /// The current position within the tokens.
     pos: usize,
 }
 
-impl Cursor {
+impl<'a> Cursor<'a> {
     /// Creates a new cursor.
-    pub(super) fn new(tokens: Vec<Token>) -> Self {
+    pub(super) fn new(tokens: &'a [Token]) -> Self {
         Self {
             tokens,
             ..Self::default()
@@ -35,7 +35,7 @@ impl Cursor {
     }
 
     /// Moves the cursor to the next token and returns the token.
-    pub(super) fn next(&mut self) -> Option<&Token> {
+    pub(super) fn next(&mut self) -> Option<&'a Token> {
         let token = self.tokens.get(self.pos);
 
         if self.pos != self.tokens.len() {
@@ -46,7 +46,7 @@ impl Cursor {
     }
 
     /// Moves the cursor to the next token after skipping tokens based on the predicate.
-    pub(super) fn next_skip<P>(&mut self, mut skip: P) -> Option<&Token>
+    pub(super) fn next_skip<P>(&mut self, mut skip: P) -> Option<&'a Token>
     where
         P: FnMut(&Token) -> bool,
     {
@@ -61,12 +61,12 @@ impl Cursor {
     }
 
     /// Peeks the next token without moving the cursor.
-    pub(super) fn peek(&self, skip: usize) -> Option<&Token> {
+    pub(super) fn peek(&self, skip: usize) -> Option<&'a Token> {
         self.tokens.get(self.pos + skip)
     }
 
     /// Peeks the next token after skipping tokens based on the predicate.
-    pub(super) fn peek_skip<P>(&self, mut skip: P) -> Option<&Token>
+    pub(super) fn peek_skip<P>(&self, mut skip: P) -> Option<&'a Token>
     where
         P: FnMut(&Token) -> bool,
     {
@@ -92,7 +92,7 @@ impl Cursor {
     }
 
     /// Peeks the previous token without moving the cursor.
-    pub(super) fn peek_prev(&self) -> Option<&Token> {
+    pub(super) fn peek_prev(&self) -> Option<&'a Token> {
         if self.pos == 0 {
             None
         } else {

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -17,7 +17,7 @@ fn check_parser(js: &str, expr: &[Node]) {
     lexer.lex().expect("failed to lex");
 
     assert_eq!(
-        Parser::new(lexer.tokens).parse_all().unwrap(),
+        Parser::new(&lexer.tokens).parse_all().unwrap(),
         Node::StatementList(expr.into())
     );
 }
@@ -26,7 +26,7 @@ fn check_invalid(js: &str) {
     let mut lexer = Lexer::new(js);
     lexer.lex().expect("failed to lex");
 
-    assert!(Parser::new(lexer.tokens).parse_all().is_err());
+    assert!(Parser::new(&lexer.tokens).parse_all().is_err());
 }
 
 #[test]

--- a/boa/src/wasm.rs
+++ b/boa/src/wasm.rs
@@ -27,7 +27,7 @@ pub fn evaluate(src: &str) -> String {
     // Setup executor
     let node: Node;
 
-    match Parser::new(tokens).parse_all() {
+    match Parser::new(&tokens).parse_all() {
         Ok(v) => {
             node = v;
         }

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -94,7 +94,7 @@ fn lex_source(src: &str) -> Result<Vec<Token>, String> {
 fn parse_tokens(tokens: Vec<Token>) -> Result<Node, String> {
     use boa::syntax::parser::Parser;
 
-    Parser::new(tokens)
+    Parser::new(&tokens)
         .parse_all()
         .map_err(|e| format!("ParsingError: {}", e))
 }


### PR DESCRIPTION
Changed `Cursor` to take in a `&[Token]` and removed unnecessary *cloning* in expression parsing for new parser #281.