### PR TITLE
Fixed positions in regexes and strict operators

### DIFF
--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -50,7 +50,6 @@ fn parser_expr(src: &str) -> Result<Node, String> {
     let mut lexer = Lexer::new(src);
     lexer.lex().map_err(|e| format!("SyntaxError: {}", e))?;
     let tokens = lexer.tokens;
-    // dbg!(&tokens);
     Parser::new(&tokens)
         .parse_all()
         .map_err(|e| format!("ParsingError: {}", e))

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -331,6 +331,18 @@ fn check_positions() {
 }
 
 #[test]
+#[ignore]
+fn test_two_divisions_in_expression() {
+    let s = "    return a !== 0 || 1 / a === 1 / b;";
+    let mut lexer = Lexer::new(s);
+    lexer.lex().expect("failed to lex");
+    dbg!(&lexer.tokens);
+
+    assert_eq!(lexer.tokens[11].pos.column_number, 37);
+    assert_eq!(lexer.tokens[11].pos.line_number, 1);
+}
+
+#[test]
 fn check_line_numbers() {
     let s = "x\ny\n";
 

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -222,28 +222,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Returns an error if the next symbol is not `tk`
-    fn expect_no_lineterminator(
-        &mut self,
-        kind: TokenKind,
-        routine: Option<&'static str>,
-    ) -> Result<(), ParseError> {
-        let next_token = self
-            .cursor
-            .next_skip(|tk| tk.kind == TokenKind::LineTerminator)
-            .ok_or(ParseError::AbruptEnd)?;
-
-        if next_token.kind == kind {
-            Ok(())
-        } else {
-            Err(ParseError::Expected(
-                vec![kind],
-                next_token.clone(),
-                routine,
-            ))
-        }
-    }
-
     /// Returns an error if the next symbol is not the punctuator `p`
     /// Consumes the next symbol otherwise
     fn expect_punc(


### PR DESCRIPTION
I also removed an unused function in the parser and added a test for #294, currently ignored. This now correctly reports the column and line number for that specific issue.