### PR TITLE
Added jemallocator only for Linux targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "criterion",
  "gc",
  "gc_derive",
+ "jemallocator",
  "rand",
  "regex",
  "serde",
@@ -60,6 +61,7 @@ name = "boa_cli"
 version = "0.7.0"
 dependencies = [
  "Boa",
+ "jemallocator",
  "structopt",
 ]
 
@@ -95,6 +97,12 @@ checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
  "rustc_version",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
@@ -228,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
 name = "gc"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +301,27 @@ name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -28,6 +28,9 @@ serde = { version = "1.0.106", features = ["derive"], optional = true }
 [dev-dependencies]
 criterion = "0.3.1"
 
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+jemallocator = "0.3.2"
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "boa"

--- a/boa/benches/exec.rs
+++ b/boa/benches/exec.rs
@@ -3,6 +3,13 @@
 use boa::{exec, realm::Realm};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg_attr(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    global_allocator
+)]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 static SYMBOL_CREATION: &str = r#"
 let a = Symbol();
 let b = Symbol();

--- a/boa/benches/lexer.rs
+++ b/boa/benches/lexer.rs
@@ -3,6 +3,13 @@
 use boa::syntax::lexer::Lexer;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg_attr(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    global_allocator
+)]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 static EXPRESSION: &str = r#"
 1 + 1 + 1 + 1 + 1 + 1 / 1 + 1 + 1 * 1 + 1 + 1 + 1;
 "#;

--- a/boa/benches/parser.rs
+++ b/boa/benches/parser.rs
@@ -3,6 +3,13 @@
 use boa::syntax::{lexer::Lexer, parser::Parser};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg_attr(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    global_allocator
+)]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 static EXPRESSION: &str = r#"
 1 + 1 + 1 + 1 + 1 + 1 / 1 + 1 + 1 * 1 + 1 + 1 + 1;
 "#;

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 Boa = { path = "../boa", features = ["serde-ast"], default-features = false }
 structopt = "0.3.13"
 
+[target.x86_64-unknown-linux-gnu.dependencies]
+jemallocator = "0.3.2"
+
 [[bin]]
 name = "boa"
 path = "src/main.rs"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -1,15 +1,51 @@
-#![deny(unused_qualifications, clippy::correctness, clippy::style)]
-#![warn(clippy::perf)]
-#![allow(clippy::cognitive_complexity)]
+#![deny(
+    unused_qualifications,
+    clippy::all,
+    unused_qualifications,
+    unused_import_braces,
+    unused_lifetimes,
+    unreachable_pub,
+    trivial_numeric_casts,
+    rustdoc,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    deprecated_in_future,
+    non_ascii_idents,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style
+)]
+#![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    clippy::cognitive_complexity,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::as_conversions
+)]
 
-use boa::builtins::console::log;
-use boa::serde_json;
-use boa::syntax::ast::{node::Node, token::Token};
-use boa::{exec::Executor, forward_val, realm::Realm};
-use std::io::{self, Write};
-use std::{fs::read_to_string, path::PathBuf};
-use structopt::clap::arg_enum;
-use structopt::StructOpt;
+use boa::{
+    builtins::console::log,
+    exec::Executor,
+    forward_val,
+    realm::Realm,
+    serde_json,
+    syntax::ast::{node::Node, token::Token},
+};
+use std::{
+    fs::read_to_string,
+    io::{self, Write},
+    path::PathBuf,
+};
+use structopt::{clap::arg_enum, StructOpt};
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg_attr(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    global_allocator
+)]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 /// CLI configuration for Boa.
 //


### PR DESCRIPTION
As per the list of [supported targets][targets] for jemallocator, it seems that only `x86_64-unknown-linux-gnu` is properly supported with all tests passing. So I added a conditional dependency that will only build in those targets and will only use jemallocator then. This fixes #309.

[targets]: https://crates.io/crates/jemallocator#user-content-platform-support