### PR TITLE
adding test for #273

### DIFF
--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -709,3 +709,21 @@ fn check_function_declarations() {
         )],
     );
 }
+
+#[test]
+/// Should be parsed as `new Class().method()` instead of `new (Class().method())`
+fn check_construct_call_precedence() {
+    check_parser(
+        "new Date().getTime()",
+        &[Node::Call(
+            Box::new(Node::GetConstField(
+                Box::new(Node::New(Box::new(Node::Call(
+                    Box::new(Node::Local(String::from("Date"))),
+                    vec![],
+                )))),
+                String::from("getTime"),
+            )),
+            vec![],
+        )],
+    )
+}


### PR DESCRIPTION
Test for constructor precedence in the parser.
It can be quite verbose to read, i'm not sure if there's a better way of testing the AST output