### PR TITLE
Added continuous integration for windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,8 @@ on:
 name: Continuous integration
 
 jobs:
-  check:
-    name: Check
+  check_on_linux:
+    name: Check on Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -22,9 +22,35 @@ jobs:
         with:
           command: check
 
-  test:
-    name: Test Suite
+  check_on_windows:
+      name: Check on Windows
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v1
+        - uses: actions-rs/toolchain@v1
+          with:
+            toolchain: stable
+            override: true
+        - uses: actions-rs/cargo@v1
+          with:
+            command: check
+
+  test_on_linux:
+    name: Test Suite on Linux
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test_on_windows:
+    name: Test Suite on Windows
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -26,7 +26,7 @@ jobs:
       name: Check on Windows
       runs-on: windows-latest
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v2
         - uses: actions-rs/toolchain@v1
           with:
             toolchain: stable
@@ -39,7 +39,7 @@ jobs:
     name: Test Suite on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -52,7 +52,7 @@ jobs:
     name: Test Suite on Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -65,7 +65,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -80,7 +80,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
I added continuous integration for windows.
 - Rename `Check` **to** `Check on Linux`
 - Added `Check on Windows`
 - Rename `Test Suite` **to** `Test Suite on Linux`
 - Added `Test Suite on Windows`

I did not add `Rust Fmt on Windows` and `Rust Clippy on Windows`, since there are not os specific.

what do you think? @Razican @jasonwilliams 

Also should I add for benchmark too?