### PR TITLE
fix #209 "Calling Array with one argument"

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -118,7 +118,7 @@ pub fn make_array(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result
     match args.len() {
         1 if args[0].is_integer() => {
             length = from_value::<i32>(args[0].clone()).expect("Could not convert argument to i32");
-            // TODO: It should not create an array of undefinds, but an empty array ("holy" array in V8) with length `n`.
+            // TODO: It should not create an array of undefineds, but an empty array ("holy" array in V8) with length `n`.
             for n in 0..length {
                 this.set_field_slice(&n.to_string(), Gc::new(ValueData::Undefined));
             }

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -125,7 +125,7 @@ pub fn make_array(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result
         }
         1 if args[0].is_double() => {
             // TODO: throw `RangeError`.
-            unimplemented!("RangeError: invalid array length");
+            panic!("RangeError: invalid array length");
         }
         _ => {
             for (n, value) in args.iter().enumerate() {

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -791,3 +791,25 @@ fn some() {
     assert_eq!(del_array_length, "3");
     assert_eq!(result, "true");
 }
+
+#[test]
+fn call_array_constructor_with_one_argument() {
+    let realm = Realm::create();
+    let mut engine = Executor::new(realm);
+    let init = r#"
+        var empty = new Array(0);
+
+        var five = new Array(5);
+
+        var one = new Array("Hello, world!");
+        "#;
+    forward(&mut engine, init);
+    let result = forward(&mut engine, "empty.length");
+    assert_eq!(result, "0");
+
+    let result = forward(&mut engine, "five.length");
+    assert_eq!(result, "5");
+
+    let result = forward(&mut engine, "one.length");
+    assert_eq!(result, "1");
+}


### PR DESCRIPTION
This is supposed to fix #209.

While trying to fix this bug I encountered another bug were we only get `Const::Num` and never `Const::Int`

This PR is blocked until it is fixed.

I will create another PR addressing that bug.