### PR TITLE
Fix #329

### DIFF
--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -16,4 +16,5 @@ structopt = "0.3.13"
 
 [[bin]]
 name = "boa"
+doc = false
 path = "src/main.rs"


### PR DESCRIPTION
This will disable documentation for the boa binary.

This should close #329  