### PR TITLE
Fixing master build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload documentation
         uses: crazy-max/ghaction-github-pages@v1
         with:
-          target_branch: gh-pages-test
+          target_branch: gh-pages
           keep_history: true
           build_dir: target/doc_upload
         env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,43 +6,7 @@ on:
 
 jobs:
   benchmark:
-    name: Run Criterion benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run benchmark
-        run: cargo bench -p Boa | tee output.txt
-      - name: Store benchmark result
-        uses: jasonwilliams/github-action-benchmark@v1
-        with:
-          name: Boa Benchmarks
-          tool: "criterion"
-          output-file-path: output.txt
-          auto-push: true
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-
-  doc-upload:
-    name: Upload documentation
+    name: Upload docs and run benchmarks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -72,11 +36,23 @@ jobs:
           command: doc
           args: -v --document-private-items
       - run: echo "<meta http-equiv=refresh content=0;url=boa/index.html>" > target/doc/index.html
+      - run: mkdir target/doc_upload && mv target/doc target/doc_upload/doc
       - name: Upload documentation
-        uses: appleboy/gh-pages-action@0.0.2
+        uses: crazy-max/ghaction-github-pages@v1
         with:
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-          remote_url: https://github.com/${{ env.GITHUB_REPOSITORY }}.git
-          target_directory: target/doc
           target_branch: gh-pages-test
+          keep_history: true
+          build_dir: target/doc_upload
+        env:
+          GITHUB_PAT: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+      - name: Run benchmark
+        run: cargo bench -p Boa | tee output.txt
+      - name: Store benchmark result
+        uses: jasonwilliams/github-action-benchmark@v1
+        with:
+          name: Boa Benchmarks
+          tool: "criterion"
+          output-file-path: output.txt
+          auto-push: true
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+


### PR DESCRIPTION
This should fix the build in the `master` branch. It will also properly upload a `doc/` folder to the `gh-pages` branch (for now using a `test` branch). This also removes the need to have a `secrets.USERNAME` in the repo.

It seems that the old action was broken, and this should be working better. I had to do a trick not to have a mess in the files in the branch, but I think it should be fine. Let's try it.