### PR TITLE
Removed the `serde-ast` feature and the `serde_json` export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ version = "0.7.0"
 dependencies = [
  "Boa",
  "jemallocator",
+ "serde_json",
  "structopt",
 ]
 
@@ -134,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+checksum = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
 dependencies = [
  "atty",
  "cast",
@@ -159,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+checksum = "ddeaf7989f00f2e1d871a26a110f3ed713632feac17f65f03ca938c542618b60"
 dependencies = [
  "cast",
  "itertools",
@@ -287,18 +288,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -633,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -744,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
+checksum = "45e4bc5ac99433e0dcb8b9f309dd271a165ae37dde129b9e0ce1bfdd8bfe4891"
 dependencies = [
  "serde",
  "serde_json",

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -10,13 +10,10 @@ license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
-[features]
-serde-ast = ["serde"]
-
 [dependencies]
 gc = "0.3.3"
 gc_derive = "0.3.2"
-serde_json = "1.0.51"
+serde_json = "1.0.52"
 rand = "0.7.3"
 regex = "1.3.7"
 
@@ -24,7 +21,7 @@ regex = "1.3.7"
 serde = { version = "1.0.106", features = ["derive"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3.1"
+criterion = "0.3.2"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 jemallocator = "0.3.2"

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -45,9 +45,6 @@ use crate::{
     syntax::{ast::node::Node, lexer::Lexer, parser::Parser},
 };
 
-#[cfg(feature = "serde-ast")]
-pub use serde_json;
-
 fn parser_expr(src: &str) -> Result<Node, String> {
     let mut lexer = Lexer::new(src);
     lexer.lex().map_err(|e| format!("SyntaxError: {}", e))?;

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -10,7 +10,7 @@
 use gc_derive::{Finalize, Trace};
 use std::fmt::{Display, Formatter, Result};
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Literals represent values in JavaScript.
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-primary-expression-literals
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum Const {
     /// A string literal is zero or more characters enclosed in double (`"`) or single (`'`) quotation marks.

--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -13,7 +13,7 @@ use std::{
     str::FromStr,
 };
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Keywords are tokens that have special meaning in JavaScript.
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [spec]: https://www.ecma-international.org/ecma-262/#sec-keywords
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Keyword {
     /// The `await` keyword.

--- a/boa/src/syntax/ast/node.rs
+++ b/boa/src/syntax/ast/node.rs
@@ -7,11 +7,11 @@ use crate::syntax::ast::{
 use gc_derive::{Finalize, Trace};
 use std::fmt;
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A Javascript AST Node.
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum Node {
     /// An array is an ordered collection of data (either primitive or object depending upon the language).
@@ -1065,7 +1065,7 @@ fn join_nodes(f: &mut fmt::Formatter<'_>, nodes: &[Node]) -> fmt::Result {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-FormalParameter
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_formal_parameter
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Trace, Finalize)]
 pub struct FormalParameter {
     pub name: String,
@@ -1099,7 +1099,7 @@ impl FormalParameter {
 /// [spec]: https://tc39.es/ecma262/#prod-PropertyDefinition
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/property/JavaScript
 // TODO: Support all features: https://tc39.es/ecma262/#prod-PropertyDefinition
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Trace, Finalize)]
 pub enum PropertyDefinition {
     /// Puts a variable into an object.
@@ -1193,7 +1193,7 @@ impl PropertyDefinition {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Trace, Finalize)]
 pub enum MethodDefinitionKind {
     /// The `get` syntax binds an object property to a function that will be called when that property is looked up.

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -3,7 +3,7 @@
 use gc_derive::{Finalize, Trace};
 use std::fmt::{Display, Formatter, Result};
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Represents an operator
@@ -25,7 +25,7 @@ pub trait Operator {
 ///  - [MDN documentation][mdn]
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Arithmetic
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum NumOp {
     /// The addition operator produces the sum of numeric operands or string concatenation.
@@ -136,7 +136,7 @@ impl Display for NumOp {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-UnaryExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Unary
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum UnaryOp {
     /// The increment operator increments (adds one to) its operand and returns a value.
@@ -343,7 +343,7 @@ impl Display for UnaryOp {
 ///  - [MDN documentation][mdn]
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum BitOp {
     /// Performs the AND operation on each pair of bits. a AND b yields 1 only if both a and b are 1.
@@ -462,7 +462,7 @@ impl Display for BitOp {
 ///
 /// [spec]: tc39.es/ecma262/#sec-testing-and-comparison-operations
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Comparison
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum CompOp {
     /// The equality operator converts the operands if they are not of the same type, then applies strict comparison.
@@ -611,7 +611,7 @@ impl Display for CompOp {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-binary-logical-operators
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Logical
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum LogOp {
     /// The logical AND operator returns the value of the first operand if it can be coerced into `false`;
@@ -655,7 +655,7 @@ impl Display for LogOp {
 }
 
 /// This represents a binary operation between two values.
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum BinOp {
     /// Numeric operation.
@@ -771,7 +771,7 @@ impl Display for BinOp {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub enum AssignOp {
     /// The addition assignment operator adds the value of the right operand to a variable and assigns the result to the variable.

--- a/boa/src/syntax/ast/pos.rs
+++ b/boa/src/syntax/ast/pos.rs
@@ -1,6 +1,6 @@
 //! This module implements the `Pos` structure, which represents a position in the source code.
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A position in the Javascript source code.
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Similar Implementations
 /// [V8: Location](https://cs.chromium.org/chromium/src/v8/src/parsing/scanner.h?type=cs&q=isValid+Location&g=0&l=216)
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Position {
     // Column number

--- a/boa/src/syntax/ast/punc.rs
+++ b/boa/src/syntax/ast/punc.rs
@@ -8,7 +8,7 @@
 use crate::syntax::ast::op::{AssignOp, BinOp, BitOp, CompOp, LogOp, NumOp};
 use std::fmt::{Display, Error, Formatter};
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The Punctuator enum describes all of the punctuators used in JavaScript.
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 ///  - [ECMAScript Reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-Punctuator
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum Punctuator {
     /// `+`

--- a/boa/src/syntax/ast/token.rs
+++ b/boa/src/syntax/ast/token.rs
@@ -8,7 +8,7 @@
 use crate::syntax::ast::{keyword::Keyword, pos::Position, punc::Punctuator};
 use std::fmt::{Debug, Display, Formatter, Result};
 
-#[cfg(feature = "serde-ast")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// This represents the smallest individual words, phrases, or characters that JavaScript can understand.
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-tokens
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     /// The token kind, which contains the actual data of the token.
@@ -57,7 +57,7 @@ impl Debug for VecToken {
 }
 
 /// Represents the type of Token and the data it has inside.
-#[cfg_attr(feature = "serde-ast", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub enum TokenKind {
     /// A boolean literal, which is either `true` or `false`.

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -11,8 +11,9 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-Boa = { path = "../boa", features = ["serde-ast"] }
-structopt = "0.3.13"
+Boa = { path = "../boa", features = ["serde"] }
+structopt = "0.3.14"
+serde_json = "1.0.52"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.3.2"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -30,7 +30,6 @@ use boa::{
     exec::Executor,
     forward_val,
     realm::Realm,
-    serde_json,
     syntax::ast::{node::Node, token::Token},
 };
 use std::{

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 Boa = { path = "../boa" }
-wasm-bindgen = { version = "0.2.60" }
+wasm-bindgen = "0.2.60"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This simplifies the `boa` crate even further: it removes the `serde-ast` feature, but the `serde` dependency is still optional, and can be activated by activating the `serde` feature (as I did in the CLI binary).

Then I also removed the export of `serde_json`. This is not a good practice, since the crates using `boa` as a library might want to use their own version of `serde_json` or any other serializer for outputing the data.

This makes it mandatory for any user of the library to add a serializer as a dependency, so I added `serde_json` as a dependency to the CLI.