### PR TITLE
Fixed doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Currently, it has support for some of the language.
 
 ## Live Demo (WASM)
 
-https://jasonwilliams.github.io/boa/
+<https://jasonwilliams.github.io/boa/>
 
 You can get more verbose errors when running from the command line
 
 ## Development documentation
 
-You can check the internal development docs at jasonwilliams.github.io/boa/doc
+You can check the internal development docs at <https://jasonwilliams.github.io/boa/doc>
 
 ## Benchmarks
 
-https://jasonwilliams.github.io/boa/dev/bench/
+<https://jasonwilliams.github.io/boa/dev/bench/>
 
 ## Contributing
 


### PR DESCRIPTION
This just fixes the link in the README to the development documentation. I also noticed that the development documentation no longer has private items since the last commit, but might have been a spurious error, since it was working just before. Let's see if it stays like this.