### PR TITLE
Changed HashMap and HashSet for Fx versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,8 +252,8 @@ checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
 name = "gc"
-version = "0.3.3"
-source = "git+https://github.com/Manishearth/rust-gc.git#87bb44e0e3b5824df1669415a2766b9ee34dc9a4"
+version = "0.3.4"
+source = "git+https://github.com/Manishearth/rust-gc.git#8d9fe40510e417a18cd7f172e6dabdbad2663e2b"
 
 [[package]]
 name = "gc_derive"
@@ -409,9 +409,9 @@ checksum = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
 
 [[package]]
 name = "plotters"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
+checksum = "f9b1d9ca091d370ea3a78d5619145d1b59426ab0c9eedbad2514a4cee08bf389"
 dependencies = [
  "js-sys",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,8 @@ checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 [[package]]
 name = "gc"
 version = "0.3.4"
-source = "git+https://github.com/Manishearth/rust-gc.git#8d9fe40510e417a18cd7f172e6dabdbad2663e2b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4917b7233397091baf9136eec3c669c8551b097d69ca2b00a2606e5f07641d1"
 dependencies = [
  "gc_derive",
 ]
@@ -260,7 +261,8 @@ dependencies = [
 [[package]]
 name = "gc_derive"
 version = "0.3.4"
-source = "git+https://github.com/Manishearth/rust-gc.git#8d9fe40510e417a18cd7f172e6dabdbad2663e2b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5b968c8044a119af2671a52de57689cbf502d6686847abd9e6252ee4c39313"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -677,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -757,9 +759,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "jemallocator",
  "rand",
  "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -252,8 +253,7 @@ checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 [[package]]
 name = "gc"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75656800ec248b3d0c33b685e442a67e7308009ae59b1f8eb60c4f09ebebb512"
+source = "git+https://github.com/Manishearth/rust-gc.git#87bb44e0e3b5824df1669415a2766b9ee34dc9a4"
 
 [[package]]
 name = "gc_derive"
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "oorandom"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+checksum = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
 
 [[package]]
 name = "plotters"
@@ -433,7 +433,7 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
  "version_check",
 ]
@@ -445,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
  "syn-mid",
  "version_check",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -468,9 +468,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -568,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -669,7 +675,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -691,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -702,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -808,9 +814,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -818,37 +824,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -856,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ version = "0.7.0"
 dependencies = [
  "criterion",
  "gc",
- "gc_derive",
  "jemallocator",
  "rand",
  "regex",
@@ -254,15 +253,18 @@ checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 name = "gc"
 version = "0.3.4"
 source = "git+https://github.com/Manishearth/rust-gc.git#8d9fe40510e417a18cd7f172e6dabdbad2663e2b"
+dependencies = [
+ "gc_derive",
+]
 
 [[package]]
 name = "gc_derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2501c15cbaf28a0c2214617aa85351982a933161d7937fe6cd71c855364e0ea6"
+version = "0.3.4"
+source = "git+https://github.com/Manishearth/rust-gc.git#8d9fe40510e417a18cd7f172e6dabdbad2663e2b"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
+ "proc-macro2",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -433,8 +435,8 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -445,8 +447,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote",
+ "syn",
  "syn-mid",
  "version_check",
 ]
@@ -457,14 +459,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -634,8 +630,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -675,19 +671,8 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
-]
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -697,8 +682,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
- "quote 1.0.4",
- "unicode-xid 0.2.0",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -708,27 +693,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.6.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -770,12 +748,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -832,8 +804,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -843,7 +815,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.4",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -854,8 +826,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-gc = { version = "0.3.4", git = "https://github.com/Manishearth/rust-gc.git", features = ["derive"] }
+gc = { version = "0.3.4", features = ["derive"] }
 serde_json = "1.0.52"
 rand = "0.7.3"
 regex = "1.3.7"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -11,8 +11,7 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-gc = { version = "0.3.3", git = "https://github.com/Manishearth/rust-gc.git" }
-gc_derive = "0.3.2"
+gc = { version = "0.3.4", git = "https://github.com/Manishearth/rust-gc.git", features = ["derive"] }
 serde_json = "1.0.52"
 rand = "0.7.3"
 regex = "1.3.7"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -11,11 +11,12 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-gc = "0.3.3"
+gc = { version = "0.3.3", git = "https://github.com/Manishearth/rust-gc.git" }
 gc_derive = "0.3.2"
 serde_json = "1.0.52"
 rand = "0.7.3"
 regex = "1.3.7"
+rustc-hash = "1.1.0"
 
 # Optional Dependencies
 serde = { version = "1.0.106", features = ["derive"], optional = true }

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -24,24 +24,15 @@ use crate::{
     exec::Interpreter,
 };
 use gc::Gc;
-use std::{collections::HashMap, time::SystemTime};
+use rustc_hash::FxHashMap;
+use std::time::SystemTime;
 
 /// This is the internal console object state.
 #[derive(Debug, Default)]
 pub struct ConsoleState {
-    count_map: HashMap<String, u32>,
-    timer_map: HashMap<String, u128>,
+    count_map: FxHashMap<String, u32>,
+    timer_map: FxHashMap<String, u128>,
     groups: Vec<String>,
-}
-
-impl ConsoleState {
-    fn new() -> Self {
-        Self {
-            count_map: HashMap::new(),
-            timer_map: HashMap::new(),
-            groups: vec![],
-        }
-    }
 }
 
 impl InternalState for ConsoleState {}
@@ -520,6 +511,6 @@ pub fn create_constructor(global: &Value) -> Value {
     make_builtin_fn!(time_end, named "timeEnd", of console);
     make_builtin_fn!(dir, named "dir", of console);
     make_builtin_fn!(dir, named "dirxml", of console);
-    console.set_internal_state(ConsoleState::new());
+    console.set_internal_state(ConsoleState::default());
     console
 }

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -23,8 +23,7 @@ use crate::{
     syntax::ast::node::{FormalParameter, Node},
     Interpreter,
 };
-use gc::{unsafe_empty_trace, Gc, Trace};
-use gc_derive::{Finalize, Trace};
+use gc::{unsafe_empty_trace, Finalize, Gc, Trace};
 use std::fmt::{self, Debug};
 
 /// _fn(this, arguments, ctx) -> ResultValue_ - The signature of a built-in function

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -23,9 +23,10 @@ use crate::{
 };
 use gc::{unsafe_empty_trace, Gc, Trace};
 use gc_derive::{Finalize, Trace};
+use rustc_hash::FxHashMap;
 use std::fmt::{self, Debug};
 use std::fmt::{Display, Error, Formatter};
-use std::{borrow::Borrow, collections::HashMap, ops::Deref};
+use std::{borrow::Borrow, ops::Deref};
 
 pub use internal_methods_trait::ObjectInternalMethods;
 pub use internal_state::{InternalState, InternalStateCell};
@@ -45,11 +46,11 @@ pub struct Object {
     /// The type of the object.
     pub kind: ObjectKind,
     /// Intfiernal Slots
-    pub internal_slots: Box<HashMap<String, Value>>,
+    pub internal_slots: Box<FxHashMap<String, Value>>,
     /// Properties
-    pub properties: Box<HashMap<String, Property>>,
+    pub properties: Box<FxHashMap<String, Property>>,
     /// Symbol Properties
-    pub sym_properties: Box<HashMap<i32, Property>>,
+    pub sym_properties: Box<FxHashMap<i32, Property>>,
     /// Some rust object that stores internal state
     pub state: Option<Box<InternalStateCell>>,
     /// [[Call]]
@@ -336,9 +337,9 @@ impl Object {
     pub fn default() -> Self {
         let mut object = Self {
             kind: ObjectKind::Ordinary,
-            internal_slots: Box::new(HashMap::new()),
-            properties: Box::new(HashMap::new()),
-            sym_properties: Box::new(HashMap::new()),
+            internal_slots: Box::new(FxHashMap::default()),
+            properties: Box::new(FxHashMap::default()),
+            sym_properties: Box::new(FxHashMap::default()),
             state: None,
             call: None,
             construct: None,
@@ -352,9 +353,9 @@ impl Object {
     pub fn function() -> Self {
         let mut object = Self {
             kind: ObjectKind::Function,
-            internal_slots: Box::new(HashMap::new()),
-            properties: Box::new(HashMap::new()),
-            sym_properties: Box::new(HashMap::new()),
+            internal_slots: Box::new(FxHashMap::default()),
+            properties: Box::new(FxHashMap::default()),
+            sym_properties: Box::new(FxHashMap::default()),
             state: None,
             call: None,
             construct: None,
@@ -394,9 +395,9 @@ impl Object {
     fn from_boolean(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::Boolean,
-            internal_slots: Box::new(HashMap::new()),
-            properties: Box::new(HashMap::new()),
-            sym_properties: Box::new(HashMap::new()),
+            internal_slots: Box::new(FxHashMap::default()),
+            properties: Box::new(FxHashMap::default()),
+            sym_properties: Box::new(FxHashMap::default()),
             state: None,
             call: None,
             construct: None,
@@ -411,9 +412,9 @@ impl Object {
     fn from_number(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::Number,
-            internal_slots: Box::new(HashMap::new()),
-            properties: Box::new(HashMap::new()),
-            sym_properties: Box::new(HashMap::new()),
+            internal_slots: Box::new(FxHashMap::default()),
+            properties: Box::new(FxHashMap::default()),
+            sym_properties: Box::new(FxHashMap::default()),
             state: None,
             call: None,
             construct: None,
@@ -428,9 +429,9 @@ impl Object {
     fn from_string(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::String,
-            internal_slots: Box::new(HashMap::new()),
-            properties: Box::new(HashMap::new()),
-            sym_properties: Box::new(HashMap::new()),
+            internal_slots: Box::new(FxHashMap::default()),
+            properties: Box::new(FxHashMap::default()),
+            sym_properties: Box::new(FxHashMap::default()),
             state: None,
             call: None,
             construct: None,

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -21,8 +21,7 @@ use crate::{
     },
     exec::Interpreter,
 };
-use gc::{unsafe_empty_trace, Gc, Trace};
-use gc_derive::{Finalize, Trace};
+use gc::{unsafe_empty_trace, Finalize, Gc, Trace};
 use rustc_hash::FxHashMap;
 use std::fmt::{self, Debug};
 use std::fmt::{Display, Error, Formatter};

--- a/boa/src/builtins/property.rs
+++ b/boa/src/builtins/property.rs
@@ -15,7 +15,7 @@
 //! [section]: https://tc39.es/ecma262/#sec-property-attributes
 
 use crate::builtins::value::{from_value, to_value, FromValue, ToValue, Value, ValueData};
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Trace};
 
 /// This represents a Javascript Property AKA The Property Descriptor.
 ///

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -13,8 +13,7 @@ use crate::builtins::{
     },
     property::Property,
 };
-use gc::{Gc, GcCell, GcCellRef};
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, GcCell, GcCellRef, Trace};
 use serde_json::{map::Map, Number as JSONNumber, Value as JSONValue};
 use std::{
     any::Any,

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use gc::Gc;
 use gc_derive::{Finalize, Trace};
-use std::collections::hash_map::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Declarative Bindings have a few properties for book keeping purposes, such as mutability (const vs let).
 /// Can it be deleted? and strict mode.
@@ -33,7 +33,7 @@ pub struct DeclarativeEnvironmentRecordBinding {
 /// declarations contained within its scope.
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct DeclarativeEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: FxHashMap<String, DeclarativeEnvironmentRecordBinding>,
     pub outer_env: Option<Environment>,
 }
 

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -12,8 +12,7 @@ use crate::{
         lexical_environment::{Environment, EnvironmentType},
     },
 };
-use gc::Gc;
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, Trace};
 use rustc_hash::FxHashMap;
 
 /// Declarative Bindings have a few properties for book keeping purposes, such as mutability (const vs let).

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use gc::Gc;
 use gc_derive::{Finalize, Trace};
-use std::collections::hash_map::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Different binding status for `this`.
 /// Usually set on a function environment record
@@ -35,7 +35,7 @@ pub enum BindingStatus {
 /// <https://tc39.es/ecma262/#table-16>
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct FunctionEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: FxHashMap<String, DeclarativeEnvironmentRecordBinding>,
     /// This is the this value used for this invocation of the function.
     pub this_value: Value,
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -16,8 +16,7 @@ use crate::{
         lexical_environment::{Environment, EnvironmentType},
     },
 };
-use gc::Gc;
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, Trace};
 use rustc_hash::FxHashMap;
 
 /// Different binding status for `this`.

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -16,8 +16,7 @@ use crate::{
         object_environment_record::ObjectEnvironmentRecord,
     },
 };
-use gc::Gc;
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, Trace};
 use rustc_hash::FxHashSet;
 
 #[derive(Debug, Trace, Finalize, Clone)]

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -18,14 +18,14 @@ use crate::{
 };
 use gc::Gc;
 use gc_derive::{Finalize, Trace};
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct GlobalEnvironmentRecord {
     pub object_record: Box<ObjectEnvironmentRecord>,
     pub global_this_binding: Value,
     pub declarative_record: Box<DeclarativeEnvironmentRecord>,
-    pub var_names: HashSet<String>,
+    pub var_names: FxHashSet<String>,
 }
 
 impl GlobalEnvironmentRecord {

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -4,20 +4,20 @@
 //!
 //! The following operations are used to operate upon lexical environments
 //! This is the entrypoint to lexical environments.
-//!
 
-use crate::builtins::value::{Value, ValueData};
-use crate::environment::declarative_environment_record::DeclarativeEnvironmentRecord;
-use crate::environment::environment_record_trait::EnvironmentRecordTrait;
-use crate::environment::function_environment_record::{BindingStatus, FunctionEnvironmentRecord};
-use crate::environment::global_environment_record::GlobalEnvironmentRecord;
-use crate::environment::object_environment_record::ObjectEnvironmentRecord;
+use crate::{
+    builtins::value::{Value, ValueData},
+    environment::{
+        declarative_environment_record::DeclarativeEnvironmentRecord,
+        environment_record_trait::EnvironmentRecordTrait,
+        function_environment_record::{BindingStatus, FunctionEnvironmentRecord},
+        global_environment_record::GlobalEnvironmentRecord,
+        object_environment_record::ObjectEnvironmentRecord,
+    },
+};
 use gc::{Gc, GcCell};
-use std::collections::hash_map::HashMap;
-use std::collections::{HashSet, VecDeque};
-use std::debug_assert;
-use std::error;
-use std::fmt;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::{collections::VecDeque, error, fmt};
 
 /// Environments are wrapped in a Box and then in a GC wrapper
 pub type Environment = Gc<GcCell<Box<dyn EnvironmentRecordTrait>>>;
@@ -217,7 +217,7 @@ impl LexicalEnvironment {
 
 pub fn new_declarative_environment(env: Option<Environment>) -> Environment {
     let boxed_env = Box::new(DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: FxHashMap::default(),
         outer_env: env,
     });
 
@@ -231,7 +231,7 @@ pub fn new_function_environment(
 ) -> Environment {
     debug_assert!(new_target.is_object() || new_target.is_undefined());
     Gc::new(GcCell::new(Box::new(FunctionEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: FxHashMap::default(),
         function: f,
         this_binding_status: BindingStatus::Uninitialized, // hardcoding to unitialized for now until short functions are properly supported
         home_object: Gc::new(ValueData::Undefined),
@@ -267,7 +267,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
     });
 
     let dcl_rec = Box::new(DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: FxHashMap::default(),
         outer_env: None,
     });
 
@@ -275,7 +275,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: HashSet::new(),
+        var_names: FxHashSet::default(),
     })))
 }
 

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -16,8 +16,7 @@ use crate::{
         lexical_environment::{Environment, EnvironmentType},
     },
 };
-use gc::Gc;
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Gc, Trace};
 
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct ObjectEnvironmentRecord {

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use gc::{Gc, GcCell};
-use std::collections::{hash_map::HashMap, hash_set::HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Representation of a Realm.
 ///
@@ -98,7 +98,7 @@ fn new_global_environment(
     });
 
     let dcl_rec = Box::new(DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: FxHashMap::default(),
         outer_env: None,
     });
 
@@ -106,6 +106,6 @@ fn new_global_environment(
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: HashSet::new(),
+        var_names: FxHashSet::default(),
     })))
 }

--- a/boa/src/syntax/ast/constant.rs
+++ b/boa/src/syntax/ast/constant.rs
@@ -7,7 +7,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-primary-expression-literals
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals
 
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Trace};
 use std::fmt::{Display, Formatter, Result};
 
 #[cfg(feature = "serde")]

--- a/boa/src/syntax/ast/node.rs
+++ b/boa/src/syntax/ast/node.rs
@@ -4,7 +4,7 @@ use crate::syntax::ast::{
     constant::Const,
     op::{BinOp, Operator, UnaryOp},
 };
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Trace};
 use std::fmt;
 
 #[cfg(feature = "serde")]

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -1,6 +1,6 @@
 //! This module implements various structure for logic handling.
 
-use gc_derive::{Finalize, Trace};
+use gc::{Finalize, Trace};
 use std::fmt::{Display, Formatter, Result};
 
 #[cfg(feature = "serde")]

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 Boa = { path = "../boa" }
-wasm-bindgen = "0.2.60"
+wasm-bindgen = "0.2.62"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This fixes #356. Note that this requires the git version of `rust-gc` until https://github.com/Manishearth/rust-gc/issues/92 gets done. An upgrade to rust-gc would also include new types implementing `Trace` OOB and a very reduced dependency tree without having to depend on many `syn` and `quote` versions.