### PR TITLE
Removed one indirection from objects

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -47,13 +47,13 @@ pub struct Object {
     /// The type of the object.
     pub kind: ObjectKind,
     /// Intfiernal Slots
-    pub internal_slots: Box<FxHashMap<String, Value>>,
+    pub internal_slots: FxHashMap<String, Value>,
     /// Properties
-    pub properties: Box<FxHashMap<String, Property>>,
+    pub properties: FxHashMap<String, Property>,
     /// Symbol Properties
-    pub sym_properties: Box<FxHashMap<i32, Property>>,
+    pub sym_properties: FxHashMap<i32, Property>,
     /// Some rust object that stores internal state
-    pub state: Option<Box<InternalStateCell>>,
+    pub state: Option<InternalStateCell>,
     /// [[Call]]
     pub call: Option<Function>,
     /// [[Construct]]
@@ -338,9 +338,9 @@ impl Object {
     pub fn default() -> Self {
         let mut object = Self {
             kind: ObjectKind::Ordinary,
-            internal_slots: Box::new(FxHashMap::default()),
-            properties: Box::new(FxHashMap::default()),
-            sym_properties: Box::new(FxHashMap::default()),
+            internal_slots: FxHashMap::default(),
+            properties: FxHashMap::default(),
+            sym_properties: FxHashMap::default(),
             state: None,
             call: None,
             construct: None,
@@ -354,9 +354,9 @@ impl Object {
     pub fn function() -> Self {
         let mut object = Self {
             kind: ObjectKind::Function,
-            internal_slots: Box::new(FxHashMap::default()),
-            properties: Box::new(FxHashMap::default()),
-            sym_properties: Box::new(FxHashMap::default()),
+            internal_slots: FxHashMap::default(),
+            properties: FxHashMap::default(),
+            sym_properties: FxHashMap::default(),
             state: None,
             call: None,
             construct: None,
@@ -396,9 +396,9 @@ impl Object {
     fn from_boolean(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::Boolean,
-            internal_slots: Box::new(FxHashMap::default()),
-            properties: Box::new(FxHashMap::default()),
-            sym_properties: Box::new(FxHashMap::default()),
+            internal_slots: FxHashMap::default(),
+            properties: FxHashMap::default(),
+            sym_properties: FxHashMap::default(),
             state: None,
             call: None,
             construct: None,
@@ -413,9 +413,9 @@ impl Object {
     fn from_number(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::Number,
-            internal_slots: Box::new(FxHashMap::default()),
-            properties: Box::new(FxHashMap::default()),
-            sym_properties: Box::new(FxHashMap::default()),
+            internal_slots: FxHashMap::default(),
+            properties: FxHashMap::default(),
+            sym_properties: FxHashMap::default(),
             state: None,
             call: None,
             construct: None,
@@ -430,9 +430,9 @@ impl Object {
     fn from_string(argument: &Value) -> Self {
         let mut obj = Self {
             kind: ObjectKind::String,
-            internal_slots: Box::new(FxHashMap::default()),
-            properties: Box::new(FxHashMap::default()),
-            sym_properties: Box::new(FxHashMap::default()),
+            internal_slots: FxHashMap::default(),
+            properties: FxHashMap::default(),
+            sym_properties: FxHashMap::default(),
             state: None,
             call: None,
             construct: None,

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -81,7 +81,7 @@ pub fn make_regexp(this: &mut Value, args: &[Value], _: &mut Interpreter) -> Res
             regex_body = body.into();
         }
         ValueData::Object(ref obj) => {
-            let slots = &*obj.borrow().internal_slots;
+            let slots = &obj.borrow().internal_slots;
             if slots.get("RegExpMatcher").is_some() {
                 // first argument is another `RegExp` object, so copy its pattern and flags
                 if let Some(body) = slots.get("OriginalSource") {

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -407,7 +407,7 @@ fn get_regex_string(value: &Value) -> String {
     match value.deref() {
         ValueData::String(ref body) => body.into(),
         ValueData::Object(ref obj) => {
-            let slots = &*obj.borrow().internal_slots;
+            let slots = &obj.borrow().internal_slots;
             if slots.get("RegExpMatcher").is_some() {
                 // first argument is another `RegExp` object, so copy its pattern and flags
                 if let Some(body) = slots.get("OriginalSource") {

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -393,10 +393,7 @@ impl ValueData {
     /// Get the internal state of an object.
     pub fn get_internal_state(&self) -> Option<InternalStateCell> {
         if let Self::Object(ref obj) = *self {
-            obj.borrow()
-                .state
-                .as_ref()
-                .map(|state| state.deref().clone())
+            obj.borrow().state.as_ref().cloned()
         } else {
             None
         }
@@ -534,7 +531,7 @@ impl ValueData {
         if let Self::Object(ref obj) = *self {
             obj.borrow_mut()
                 .state
-                .replace(Box::new(InternalStateCell::new(state)));
+                .replace(InternalStateCell::new(state));
         }
     }
 


### PR DESCRIPTION
Objects were using boxed hashmaps and RCs, which does not make much sense, since the data in a hashmap is already in the heap, so I just changed that. It should be a small optimization.