### PR TITLE
String wasn't defaulting to empty when called as String() with no arg…

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -32,13 +32,11 @@ use std::{
 /// [[Construct]] - Creates a new instance `this`
 ///
 /// [[Call]] - Returns a new native `string`
+/// <https://tc39.es/ecma262/#sec-string-constructor-string-value>
 pub fn make_string(this: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
     // This value is used by console.log and other routines to match Obexpecty"failed to parse argument for String method"pe
     // to its Javascript Identifier (global constructor method name)
-    let s = args
-        .get(0)
-        .expect("failed to get StringData for make_string()")
-        .clone();
+    let s = args.get(0).unwrap_or(&Value::string("")).clone();
     let length_str = s.to_string().chars().count();
 
     this.set_field_slice("length", Value::from(length_str as i32));


### PR DESCRIPTION
The tests for this are in https://github.com/jasonwilliams/boa/pull/396 and it should unblock that PR also